### PR TITLE
nar/narinfo/types.go: fix StorePath comment

### DIFF
--- a/nar/narinfo/types.go
+++ b/nar/narinfo/types.go
@@ -9,7 +9,7 @@ import (
 
 // NarInfo represents a parsed .narinfo file
 type NarInfo struct {
-	StorePath string // The full nix store path (/nix/store/…-name-version)
+	StorePath string // The full nix store path (/nix/store/…-pname-version)
 
 	URL         string // The relative location to the .nar[.xz,…] file. Usually nar/$fileHash.nar[.xz]
 	Compression string // The compression method file at URL is compressed with (none,xz,…)


### PR DESCRIPTION
$name is usually everything that comes after the output hash.
We sometimes distinguish by using pname and version, let's use this as
an example.