### PR TITLE
pkg/wire: Write* tests

### DIFF
--- a/pkg/wire/read_test.go
+++ b/pkg/wire/read_test.go
@@ -9,6 +9,36 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// nolint:gochecknoglobals
+var (
+	wireBytesFalse       = []byte{0, 0, 0, 0, 0, 0, 0, 0}
+	wireBytesTrue        = []byte{1, 0, 0, 0, 0, 0, 0, 0}
+	wireBytesInvalidBool = []byte{2, 0, 0, 0, 0, 0, 0, 0}
+
+	contents8Bytes = []byte{
+		42, 23, 42, 23, 42, 23, 42, 23, // the actual data
+	}
+	wire8Bytes = []byte{
+		8, 0, 0, 0, 0, 0, 0, 0, // length field - 8 bytes
+		42, 23, 42, 23, 42, 23, 42, 23, // the actual data
+	}
+
+	contents10Bytes = []byte{
+		42, 23, 42, 23, 42, 23, 42, 23, // the actual data
+		42, 23,
+	}
+	wire10Bytes = []byte{
+		10, 0, 0, 0, 0, 0, 0, 0, // length field - 8 bytes
+		42, 23, 42, 23, 42, 23, 42, 23, // the actual data
+		42, 23, 0, 0, 0, 0, 0, 0, // more actual data (2 bytes), then padding
+	}
+
+	wireStringFoo = []byte{
+		3, 0, 0, 0, 0, 0, 0, 0, // length field - 3 bytes
+		0x46, 0x6F, 0x6F, 0, 0, 0, 0, 0, // contents, Foo, then 5 bytes padding
+	}
+)
+
 // hesitantReader implements an io.Reader.
 type hesitantReader struct {
 	data [][]byte
@@ -56,9 +86,9 @@ func TestReadUint64Slow(t *testing.T) {
 
 // TestReadBool tests reading boolean values works.
 func TestReadBool(t *testing.T) {
-	rdBytesFalse := bytes.NewReader([]byte{0, 0, 0, 0, 0, 0, 0, 0})
-	rdBytesTrue := bytes.NewReader([]byte{1, 0, 0, 0, 0, 0, 0, 0})
-	rdBytesInvalidBool := bytes.NewReader([]byte{2, 0, 0, 0, 0, 0, 0, 0})
+	rdBytesFalse := bytes.NewReader(wireBytesFalse)
+	rdBytesTrue := bytes.NewReader(wireBytesTrue)
+	rdBytesInvalidBool := bytes.NewReader(wireBytesInvalidBool)
 
 	v, err := wire.ReadBool(rdBytesFalse)
 	if assert.NoError(t, err) {
@@ -75,69 +105,53 @@ func TestReadBool(t *testing.T) {
 }
 
 func TestReadBytes(t *testing.T) {
-	payload8Bytes := []byte{
-		8, 0, 0, 0, 0, 0, 0, 0, // length field - 8 bytes
-		42, 23, 42, 23, 42, 23, 42, 23, // the actual data
-	}
-
-	buf, err := wire.ReadBytesFull(bytes.NewReader(payload8Bytes), 1024)
+	buf, err := wire.ReadBytesFull(bytes.NewReader(wire8Bytes), 1024)
 	if assert.NoError(t, err) {
 		assert.Equal(t, 8, len(buf))
-		assert.Equal(t, buf, []byte{42, 23, 42, 23, 42, 23, 42, 23})
+		assert.Equal(t, buf, contents8Bytes)
 	}
 
-	payload10Bytes := []byte{
-		10, 0, 0, 0, 0, 0, 0, 0, // length field - 8 bytes
-		42, 23, 42, 23, 42, 23, 42, 23, // the actual data
-		42, 23, 0, 0, 0, 0, 0, 0, // more actual data (2 bytes), then padding
-	}
-
-	buf, err = wire.ReadBytesFull(bytes.NewReader(payload10Bytes), 1024)
+	buf, err = wire.ReadBytesFull(bytes.NewReader(wire10Bytes), 1024)
 	if assert.NoError(t, err) {
 		assert.Equal(t, 10, len(buf))
-		assert.Equal(t, buf, []byte{42, 23, 42, 23, 42, 23, 42, 23, 42, 23})
+		assert.Equal(t, buf, contents10Bytes)
 	}
 
 	// concatenate the 10 bytes, then 8 bytes dummy data together,
 	// and see if we can get out both bytes. This will test we properly skip over the padding.
 	payloadCombined := []byte{}
-	payloadCombined = append(payloadCombined, payload10Bytes...)
-	payloadCombined = append(payloadCombined, payload8Bytes...)
+	payloadCombined = append(payloadCombined, wire10Bytes...)
+	payloadCombined = append(payloadCombined, wire8Bytes...)
 
 	rd := bytes.NewReader(payloadCombined)
 
 	buf, err = wire.ReadBytesFull(rd, 1024)
 	if assert.NoError(t, err) {
 		assert.Equal(t, 10, len(buf))
-		assert.Equal(t, buf, []byte{42, 23, 42, 23, 42, 23, 42, 23, 42, 23})
+		assert.Equal(t, buf, contents10Bytes)
 	}
 
 	buf, err = wire.ReadBytesFull(rd, 1024)
 	if assert.NoError(t, err) {
 		assert.Equal(t, 8, len(buf))
-		assert.Equal(t, buf, []byte{42, 23, 42, 23, 42, 23, 42, 23})
+		assert.Equal(t, buf, contents8Bytes)
 	}
 }
 
 func TestReadString(t *testing.T) {
-	payloadFoo := []byte{
-		3, 0, 0, 0, 0, 0, 0, 0, // length field - 3 bytes
-		0x46, 0x6F, 0x6F, 0, 0, 0, 0, 0, // contents, Foo, then 5 bytes padding
-	}
-
-	s, err := wire.ReadString(bytes.NewReader(payloadFoo), 1024)
+	s, err := wire.ReadString(bytes.NewReader(wireStringFoo), 1024)
 	if assert.NoError(t, err) {
 		assert.Equal(t, s, "Foo")
 	}
 
 	// exceeding max should error
-	rd := bytes.NewReader(payloadFoo)
+	rd := bytes.NewReader(wireStringFoo)
 	_, err = wire.ReadString(rd, 2)
 	assert.Error(t, err)
 
 	// the reader should not have seeked to the end of the packet
 	buf, err := io.ReadAll(rd)
 	if assert.NoError(t, err, "reading the rest shouldn't error") {
-		assert.Equal(t, payloadFoo[8:], buf, "the reader should not have seeked to the end of the packet")
+		assert.Equal(t, wireStringFoo[8:], buf, "the reader should not have seeked to the end of the packet")
 	}
 }

--- a/pkg/wire/write_test.go
+++ b/pkg/wire/write_test.go
@@ -1,0 +1,52 @@
+package wire_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/nix-community/go-nix/pkg/wire"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteUint64(t *testing.T) {
+	var buf bytes.Buffer
+
+	err := wire.WriteUint64(&buf, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, wireBytesTrue, buf.Bytes())
+}
+
+func TestWriteBool(t *testing.T) {
+	var buf bytes.Buffer
+
+	err := wire.WriteBool(&buf, true)
+	assert.NoError(t, err)
+	assert.Equal(t, wireBytesTrue, buf.Bytes())
+
+	buf.Reset()
+	err = wire.WriteBool(&buf, false)
+	assert.NoError(t, err)
+	assert.Equal(t, wireBytesFalse, buf.Bytes())
+}
+
+func TestWriteBytes(t *testing.T) {
+	var buf bytes.Buffer
+
+	err := wire.WriteBytes(&buf, contents8Bytes)
+	assert.NoError(t, err)
+	assert.Equal(t, wire8Bytes, buf.Bytes())
+
+	buf.Reset()
+
+	err = wire.WriteBytes(&buf, contents10Bytes)
+	assert.NoError(t, err)
+	assert.Equal(t, wire10Bytes, buf.Bytes())
+}
+
+func TestWriteString(t *testing.T) {
+	var buf bytes.Buffer
+
+	err := wire.WriteString(&buf, "Foo")
+	assert.NoError(t, err)
+	assert.Equal(t, wireStringFoo, buf.Bytes())
+}


### PR DESCRIPTION
This adds some tests for the `pkg/wire.Write*` functions.

Some of the magic bytes used in the read tests is moved to global variables, to allow re-use.