### PR TITLE
feat(pkg/nar): introduce NAR writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Methods to serialize and deserialize some of the hashes used in nix code and
 `.narinfo` files.
 
 ## `pkg/nar`
-A Nix ARchive (NAR) file parser that mimics `archive/tar` from the stdlib
+A Nix ARchive (NAR) file Reader and Writer, with an interface similar to
+`archive/tar` from the stdlib
 
 ## `pkg/nar/ls`
 A parser for .ls files (providing an index for .nar files)

--- a/pkg/nar/fixtures_test.go
+++ b/pkg/nar/fixtures_test.go
@@ -19,6 +19,38 @@ func genEmptyNar() []byte {
 	return expectedBuf.Bytes()
 }
 
+// genEmptyDirectoryNar returns the bytes of a NAR file only containing an empty directory.
+func genEmptyDirectoryNar() []byte {
+	var expectedBuf bytes.Buffer
+
+	err := wire.WriteString(&expectedBuf, "nix-archive-1")
+	if err != nil {
+		panic(err)
+	}
+
+	err = wire.WriteString(&expectedBuf, "(")
+	if err != nil {
+		panic(err)
+	}
+
+	err = wire.WriteString(&expectedBuf, "type")
+	if err != nil {
+		panic(err)
+	}
+
+	err = wire.WriteString(&expectedBuf, "directory")
+	if err != nil {
+		panic(err)
+	}
+
+	err = wire.WriteString(&expectedBuf, ")")
+	if err != nil {
+		panic(err)
+	}
+
+	return expectedBuf.Bytes()
+}
+
 // genOneByteRegularNar returns the bytes of a NAR only containing a single file at the root.
 func genOneByteRegularNar() []byte {
 	var expectedBuf bytes.Buffer

--- a/pkg/nar/fixtures_test.go
+++ b/pkg/nar/fixtures_test.go
@@ -1,0 +1,104 @@
+package nar_test
+
+import (
+	"bytes"
+
+	"github.com/nix-community/go-nix/pkg/wire"
+)
+
+// genEmptyNar returns just the magic header, without any actual nodes
+// this is no valid NAR file, as it needs to contain at least a root.
+func genEmptyNar() []byte {
+	var expectedBuf bytes.Buffer
+
+	err := wire.WriteString(&expectedBuf, "nix-archive-1")
+	if err != nil {
+		panic(err)
+	}
+
+	return expectedBuf.Bytes()
+}
+
+// genOneByteRegularNar returns the bytes of a NAR only containing a single file at the root.
+func genOneByteRegularNar() []byte {
+	var expectedBuf bytes.Buffer
+
+	err := wire.WriteString(&expectedBuf, "nix-archive-1")
+	if err != nil {
+		panic(err)
+	}
+
+	err = wire.WriteString(&expectedBuf, "(")
+	if err != nil {
+		panic(err)
+	}
+
+	err = wire.WriteString(&expectedBuf, "type")
+	if err != nil {
+		panic(err)
+	}
+
+	err = wire.WriteString(&expectedBuf, "regular")
+	if err != nil {
+		panic(err)
+	}
+
+	err = wire.WriteString(&expectedBuf, "contents")
+	if err != nil {
+		panic(err)
+	}
+
+	err = wire.WriteBytes(&expectedBuf, []byte{0x1})
+	if err != nil {
+		panic(err)
+	}
+
+	err = wire.WriteString(&expectedBuf, ")")
+	if err != nil {
+		panic(err)
+	}
+
+	return expectedBuf.Bytes()
+}
+
+// genSymlinkNar returns the bytes of a NAR only containing a single symlink at the root.
+func genSymlinkNar() []byte {
+	var expectedBuf bytes.Buffer
+
+	err := wire.WriteString(&expectedBuf, "nix-archive-1")
+	if err != nil {
+		panic(err)
+	}
+
+	err = wire.WriteString(&expectedBuf, "(")
+	if err != nil {
+		panic(err)
+	}
+
+	err = wire.WriteString(&expectedBuf, "type")
+	if err != nil {
+		panic(err)
+	}
+
+	err = wire.WriteString(&expectedBuf, "symlink")
+	if err != nil {
+		panic(err)
+	}
+
+	err = wire.WriteString(&expectedBuf, "target")
+	if err != nil {
+		panic(err)
+	}
+
+	err = wire.WriteString(&expectedBuf, "/nix/store/somewhereelse")
+	if err != nil {
+		panic(err)
+	}
+
+	err = wire.WriteString(&expectedBuf, ")")
+	if err != nil {
+		panic(err)
+	}
+
+	return expectedBuf.Bytes()
+}

--- a/pkg/nar/ls/list.go
+++ b/pkg/nar/ls/list.go
@@ -38,7 +38,7 @@ func ParseLS(r io.Reader) (*Root, error) {
 	}
 
 	if root.Version != 1 {
-		return nil, fmt.Errorf("invalide version %d", root.Version)
+		return nil, fmt.Errorf("invalid version %d", root.Version)
 	}
 
 	return &root, err

--- a/pkg/nar/reader.go
+++ b/pkg/nar/reader.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"path/filepath"
 
-	"github.com/nix-community/go-nix/pkg/nixpath"
 	"github.com/nix-community/go-nix/pkg/wire"
 )
 
@@ -260,7 +259,7 @@ func (nr *Reader) parseNode(path string) error {
 				}
 
 				// validate the name matches NameRe (no slashes etc.)
-				if !nixpath.NameRe.Match([]byte(currentToken)) {
+				if !NodeNameRegexp.MatchString(currentToken) {
 					return fmt.Errorf("name `%v` is invalid", currentToken)
 				}
 

--- a/pkg/nar/reader.go
+++ b/pkg/nar/reader.go
@@ -309,19 +309,18 @@ func (nr *Reader) Next() (*Header, error) {
 	// else, resume the parser
 	nr.next <- true
 
-	var header *Header
-
 	// return either an error or headers
 	select {
-	case header = <-nr.headers:
+	case header := <-nr.headers:
+		return header, nil
 	case err := <-nr.errors:
 		if err != nil {
 			// blow fuse
 			nr.err = err
 		}
+
+		return nil, err
 	}
-	// we never reach this
-	return header, nr.err
 }
 
 // Read reads from the current file in the NAR archive. It returns (0, io.EOF)

--- a/pkg/nar/reader_test.go
+++ b/pkg/nar/reader_test.go
@@ -27,6 +27,27 @@ func TestReaderEmpty(t *testing.T) {
 	}, "closing the reader shouldn't panic")
 }
 
+func TestReaderEmptyDirectory(t *testing.T) {
+	nr, err := nar.NewReader(bytes.NewBuffer(genEmptyDirectoryNar()))
+	assert.NoError(t, err)
+
+	// get first header
+	hdr, err := nr.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, &nar.Header{
+		Path: "",
+		Type: nar.TypeDirectory,
+	}, hdr)
+
+	hdr, err = nr.Next()
+	assert.Equal(t, io.EOF, err, "Next() should return io.EOF as error")
+	assert.Nil(t, hdr, "returned header should be nil")
+
+	assert.NotPanics(t, func() {
+		nr.Close()
+	}, "closing the reader shouldn't panic")
+}
+
 func TestReaderOneByteRegular(t *testing.T) {
 	nr, err := nar.NewReader(bytes.NewBuffer(genOneByteRegularNar()))
 	assert.NoError(t, err)

--- a/pkg/nar/types.go
+++ b/pkg/nar/types.go
@@ -1,5 +1,12 @@
 package nar
 
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/nix-community/go-nix/pkg/nixpath"
+)
+
 const narVersionMagic1 = "nix-archive-1"
 
 // Enum of all the node types possible.
@@ -13,6 +20,8 @@ const (
 	// TypeSymlink represents a file symlink.
 	TypeSymlink = NodeType("symlink")
 )
+
+var NodeNameRegexp = regexp.MustCompile(fmt.Sprintf("^%v$", nixpath.NameRe))
 
 func (t NodeType) String() string {
 	return string(t)

--- a/pkg/nar/writer.go
+++ b/pkg/nar/writer.go
@@ -1,0 +1,319 @@
+package nar
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/nix-community/go-nix/pkg/wire"
+)
+
+// Writer provides sequential writing of a NAR (Nix Archive) file.
+// Writer.WriteHeader begins a new file with the provided Header,
+// and then Writer can be treated as an io.Writer to supply that
+// file's data.
+type Writer struct {
+	w             io.Writer
+	contentWriter io.WriteCloser
+
+	// channels used by the goroutine to communicate back to WriteHeader and Close.
+	doneWritingHeader chan interface{} // goroutine is done writing that header, WriteHeader() can return.
+	errors            chan error       // there were errors while writing
+
+	// this is used to send new headers to write to the emitter
+	headers chan *Header
+}
+
+// NewWriter creates a new Writer writing to w.
+func NewWriter(w io.Writer) (*Writer, error) {
+	// write magic
+	err := wire.WriteString(w, narVersionMagic1)
+	if err != nil {
+		return nil, err
+	}
+
+	narWriter := &Writer{
+		w: w,
+
+		doneWritingHeader: make(chan interface{}),
+		errors:            make(chan error),
+
+		headers: make(chan *Header),
+	}
+
+	// kick off the goroutine
+	go func() {
+		// wait for the first WriteHeader() call
+		header, ok := <-narWriter.headers
+		// immediate Close(), without ever calling WriteHeader()
+		// as an empty nar is invalid, we return an error
+		if !ok {
+			narWriter.errors <- fmt.Errorf("unexpected Close()")
+			close(narWriter.errors)
+
+			return
+		}
+
+		// ensure the first item received always has an empty path.
+		if header.Path != "" {
+			narWriter.errors <- fmt.Errorf("first header always needs to have an empty path")
+			close(narWriter.errors)
+
+			return
+		}
+
+		excessHdr, err := narWriter.emitNode(header)
+		if err != nil {
+			narWriter.errors <- err
+		}
+
+		if excessHdr != nil {
+			narWriter.errors <- fmt.Errorf("additional header detected: %+v", excessHdr)
+		}
+
+		close(narWriter.errors)
+	}()
+
+	return narWriter, nil
+}
+
+// emitNode writes one NAR node. It'll internally consume one or more headers.
+// in case the header received a header that's not inside its own jurisdiction,
+// it'll return it, assuming an upper level will handle it.
+func (nw *Writer) emitNode(currentHeader *Header) (*Header, error) {
+	// write a opening (
+	err := wire.WriteString(nw.w, "(")
+	if err != nil {
+		return nil, err
+	}
+
+	// write type
+	err = wire.WriteString(nw.w, "type")
+	if err != nil {
+		return nil, err
+	}
+
+	// store the current type in a var, we access it more often later.
+	currentType := currentHeader.Type
+
+	err = wire.WriteString(nw.w, currentType.String())
+	if err != nil {
+		return nil, err
+	}
+
+	if currentType == TypeRegular { //nolint:nestif
+		// if the executable bit is set…
+		if currentHeader.Executable {
+			// write the executable token.
+			err = wire.WriteString(nw.w, "executable")
+			if err != nil {
+				return nil, err
+			}
+
+			// write the placeholder
+			err = wire.WriteBytes(nw.w, []byte{})
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// write the contents keyword
+		err = wire.WriteString(nw.w, "contents")
+		if err != nil {
+			return nil, err
+		}
+
+		nw.contentWriter, err = wire.NewBytesWriter(nw.w, uint64(currentHeader.Size))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// The directory case doesn't write anything special after ( type directory .
+	// We need to inspect the next header before figuring out whether to list entries or not.
+	if currentType == TypeSymlink || currentType == TypeDirectory { // nolint:nestif
+		if currentType == TypeSymlink {
+			// write the target keyword
+			err = wire.WriteString(nw.w, "target")
+			if err != nil {
+				return nil, err
+			}
+
+			// write the target location
+			err = wire.WriteString(nw.w, currentHeader.LinkTarget)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// setup a dummy content write, that's not connected to the main writer,
+		// and will fail if you write anything to it.
+		var b bytes.Buffer
+
+		nw.contentWriter, err = wire.NewBytesWriter(&b, 0)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// return from WriteHeader()
+	nw.doneWritingHeader <- true
+
+	// wait till we receive a new header
+	nextHeader, ok := <-nw.headers
+
+	// Close the content writer to finish the packet and write possible padding
+	// This is a no-op for symlinks and directories, as the contentWriter is limited to 0 bytes,
+	// and not connected to the main writer.
+	// The writer itself will already ensure we wrote the right amount of bytes
+	err = nw.contentWriter.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	// if this was the last header, write the closing ) and return
+	if !ok {
+		err = wire.WriteString(nw.w, ")")
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, err
+	}
+
+	// This is a loop, as nextHeader can either be what we received above,
+	// or in the case of a directory, something returned when recursing up.
+	for {
+		// if this was the last header, write the closing ) and return
+		if nextHeader == nil {
+			err = wire.WriteString(nw.w, ")")
+			if err != nil {
+				return nil, err
+			}
+
+			return nil, err
+		}
+
+		// compare Path of the received header.
+		// It needs to be lexicographically greater the previous one.
+		if cmp := strings.Compare(currentHeader.Path, nextHeader.Path); cmp != -1 {
+			return nil, fmt.Errorf(
+				"received %v, which isn't lexicographically greater than the previous one %v",
+				nextHeader.Path,
+				currentHeader.Path,
+			)
+		}
+
+		// calculate the relative path between the previous and now-read header
+		nodeName, err := filepath.Rel(currentHeader.Path, nextHeader.Path)
+		if err != nil {
+			return nil, err
+		}
+
+		// if the received header is something further up, or a sibling, we're done here.
+		if len(nodeName) > 2 && (nodeName[0:2] == "..") {
+			// write the closing )
+			err = wire.WriteString(nw.w, ")")
+			if err != nil {
+				return nil, err
+			}
+
+			// bounce further work up to above
+			return nextHeader, nil
+		}
+
+		// in other cases, it describes something below.
+		// This only works if we previously were in a directory.
+		if currentHeader.Type != TypeDirectory {
+			return nil, fmt.Errorf("received descending path %v, but we're a %v", nextHeader.Path, currentHeader.Type.String())
+		}
+
+		// Each directory needs to be its own node,
+		// so no slashes in the nodeName / relative path allowed.
+		if !NodeNameRegexp.MatchString(nodeName) {
+			return nil, fmt.Errorf("name %v is invalid", nodeName)
+		}
+
+		// write the entry keyword
+		err = wire.WriteString(nw.w, "entry")
+		if err != nil {
+			return nil, err
+		}
+
+		// write a opening (
+		err = wire.WriteString(nw.w, "(")
+		if err != nil {
+			return nil, err
+		}
+
+		// write a opening name
+		err = wire.WriteString(nw.w, "name")
+		if err != nil {
+			return nil, err
+		}
+
+		// write the node name
+		err = wire.WriteString(nw.w, nodeName)
+		if err != nil {
+			return nil, err
+		}
+
+		// write the node keyword
+		err = wire.WriteString(nw.w, "node")
+		if err != nil {
+			return nil, err
+		}
+
+		// Emit the node inside. It'll consume another node, which is what we'll
+		// handle in the next loop iteration.
+		nextHeader, err = nw.emitNode(nextHeader)
+		if err != nil {
+			return nil, err
+		}
+
+		// write the closing ) (from entry)
+		err = wire.WriteString(nw.w, ")")
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
+// WriteHeader writes hdr and prepares to accept the file's contents. The
+// Header.Size determines how many bytes can be written for the next file. If
+// the current file is not fully written, then this returns an error. This
+// implicitly flushes any padding necessary before writing the header.
+func (nw *Writer) WriteHeader(hdr *Header) error {
+	nw.headers <- hdr
+	select {
+	case err := <-nw.errors:
+		return err
+	case <-nw.doneWritingHeader:
+	}
+
+	return nil
+}
+
+// Write writes to the current file in the NAR.
+// Write returns the ErrWriteTooLong if more than Header.Size bytes
+// are written after WriteHeader.
+//
+// Calling Write on special types like TypeLink, TypeSymlink, TypeChar,
+// TypeBlock, TypeDir, and TypeFifo returns (0, ErrWriteTooLong) regardless of
+// what the Header.Size claims.
+func (nw *Writer) Write(b []byte) (int, error) {
+	return nw.contentWriter.Write(b)
+}
+
+// Close closes the NAR file.
+// If the current file (from a prior call to WriteHeader) is not fully
+// written, then this returns an error.
+func (nw *Writer) Close() error {
+	// signal the emitter this was the last one
+	close(nw.headers)
+
+	// wait for it to signal its done (by closing errors)
+	return <-nw.errors
+}

--- a/pkg/nar/writer_test.go
+++ b/pkg/nar/writer_test.go
@@ -19,6 +19,25 @@ func TestWriterEmpty(t *testing.T) {
 	assert.Error(t, nw.Close())
 }
 
+func TestWriterEmptyDirectory(t *testing.T) {
+	var buf bytes.Buffer
+	nw, err := nar.NewWriter(&buf)
+	assert.NoError(t, err)
+
+	hdr := &nar.Header{
+		Path: "",
+		Type: nar.TypeDirectory,
+	}
+
+	err = nw.WriteHeader(hdr)
+	assert.NoError(t, err)
+
+	err = nw.Close()
+	assert.NoError(t, err)
+
+	assert.Equal(t, genEmptyDirectoryNar(), buf.Bytes())
+}
+
 // TestWriterOneByteRegular writes a NAR only containing a single file at the root.
 func TestWriterOneByteRegular(t *testing.T) {
 	var buf bytes.Buffer

--- a/pkg/nar/writer_test.go
+++ b/pkg/nar/writer_test.go
@@ -1,0 +1,266 @@
+package nar_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/nix-community/go-nix/pkg/nar"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriterEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	nw, err := nar.NewWriter(&buf)
+	assert.NoError(t, err)
+
+	// calling close on an empty NAR is an error, as it'd be invalid.
+	assert.Error(t, nw.Close())
+}
+
+// TestWriterOneByteRegular writes a NAR only containing a single file at the root.
+func TestWriterOneByteRegular(t *testing.T) {
+	var buf bytes.Buffer
+	nw, err := nar.NewWriter(&buf)
+	assert.NoError(t, err)
+
+	hdr := nar.Header{
+		Path:       "",
+		Type:       nar.TypeRegular,
+		Size:       1,
+		Executable: false,
+	}
+
+	err = nw.WriteHeader(&hdr)
+	assert.NoError(t, err)
+
+	num, err := nw.Write([]byte{1})
+	assert.Equal(t, num, 1)
+	assert.NoError(t, err)
+
+	err = nw.Close()
+	assert.NoError(t, err)
+
+	assert.Equal(t, genOneByteRegularNar(), buf.Bytes())
+}
+
+// TestWriterSymlink writes a NAR only containing a symlink.
+func TestWriterSymlink(t *testing.T) {
+	var buf bytes.Buffer
+	nw, err := nar.NewWriter(&buf)
+	assert.NoError(t, err)
+
+	hdr := nar.Header{
+		Path:       "",
+		Type:       nar.TypeSymlink,
+		LinkTarget: "/nix/store/somewhereelse",
+		Size:       0,
+		Executable: false,
+	}
+
+	err = nw.WriteHeader(&hdr)
+	assert.NoError(t, err)
+
+	err = nw.Close()
+	assert.NoError(t, err)
+
+	assert.Equal(t, genSymlinkNar(), buf.Bytes())
+}
+
+// TestWriterSmoketest reads in our example nar, feeds it to the NAR reader,
+// and collects all headers and contents returned
+// It'll then use this to drive the NAR writer, and will compare the output
+// to be the same as originally read in.
+func TestWriterSmoketest(t *testing.T) {
+	f, err := os.Open("../../test/testdata/nar_1094wph9z4nwlgvsd53abfz8i117ykiv5dwnq9nnhz846s7xqd7d.nar")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// read in the NAR contents once
+	narContents, err := io.ReadAll(f)
+	assert.NoError(t, err)
+
+	// pass them into a NAR reader
+	nr, err := nar.NewReader(bytes.NewReader(narContents))
+	assert.NoError(t, err)
+
+	headers := []*nar.Header{}
+	contents := [][]byte{}
+
+	for {
+		hdr, e := nr.Next()
+		if e == io.EOF {
+			break
+		}
+
+		headers = append(headers, hdr)
+
+		fileContents, err := io.ReadAll(nr)
+		assert.NoError(t, err)
+
+		contents = append(contents, fileContents)
+	}
+
+	assert.True(t, len(headers) == len(contents), "headers and contents should have the same size")
+
+	// drive the nar writer
+	var buf bytes.Buffer
+	nw, err := nar.NewWriter(&buf)
+	assert.NoError(t, err)
+
+	// Loop over all headers
+	for i, hdr := range headers {
+		// Write header
+		err := nw.WriteHeader(hdr)
+		assert.NoError(t, err)
+
+		// Write contents. In the case of directories and symlinks, it should be fine to write empty bytes
+		n, err := io.Copy(nw, bytes.NewReader(contents[i]))
+		assert.NoError(t, err)
+		assert.Equal(t, int64(len(contents[i])), n)
+	}
+
+	err = nw.Close()
+	assert.NoError(t, err)
+	// check the NAR writer produced the same contents than what we read in
+	assert.Equal(t, narContents, buf.Bytes())
+}
+
+func TestWriterErrorsTransitions(t *testing.T) {
+	t.Run("missing directory in between", func(t *testing.T) {
+		var buf bytes.Buffer
+		nw, err := nar.NewWriter(&buf)
+		assert.NoError(t, err)
+
+		// write a directory node
+		err = nw.WriteHeader(&nar.Header{
+			Path: "",
+			Type: nar.TypeDirectory,
+		})
+		assert.NoError(t, err)
+
+		// write a symlink "a/foo", but missing the directory node "a" in between should error
+		err = nw.WriteHeader(&nar.Header{
+			Path:       "a/foo",
+			Type:       nar.TypeSymlink,
+			LinkTarget: "doesntmatter",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("missing directory at the beginning, writing another directory", func(t *testing.T) {
+		var buf bytes.Buffer
+		nw, err := nar.NewWriter(&buf)
+		assert.NoError(t, err)
+
+		// write a directory node for "a" without writing the one for ""
+		err = nw.WriteHeader(&nar.Header{
+			Path: "a",
+			Type: nar.TypeDirectory,
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("missing directory at the beginning, writing a symlink", func(t *testing.T) {
+		var buf bytes.Buffer
+		nw, err := nar.NewWriter(&buf)
+		assert.NoError(t, err)
+
+		// write a symlink for "a" without writing the directory one for ""
+		err = nw.WriteHeader(&nar.Header{
+			Path:       "a",
+			Type:       nar.TypeSymlink,
+			LinkTarget: "foo",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("transition via a symlink, not directory", func(t *testing.T) {
+		var buf bytes.Buffer
+		nw, err := nar.NewWriter(&buf)
+		assert.NoError(t, err)
+
+		// write a directory node
+		err = nw.WriteHeader(&nar.Header{
+			Path: "",
+			Type: nar.TypeDirectory,
+		})
+		assert.NoError(t, err)
+
+		// write a symlink node for "a"
+		err = nw.WriteHeader(&nar.Header{
+			Path:       "a",
+			Type:       nar.TypeSymlink,
+			LinkTarget: "doesntmatter",
+		})
+		assert.NoError(t, err)
+
+		// write a symlink "a/b", which should fail, as a was a symlink, not directory
+		err = nw.WriteHeader(&nar.Header{
+			Path:       "a/b",
+			Type:       nar.TypeSymlink,
+			LinkTarget: "doesntmatter",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("not lexicographically sorted", func(t *testing.T) {
+		var buf bytes.Buffer
+		nw, err := nar.NewWriter(&buf)
+		assert.NoError(t, err)
+
+		// write a directory node
+		err = nw.WriteHeader(&nar.Header{
+			Path: "",
+			Type: nar.TypeDirectory,
+		})
+		assert.NoError(t, err)
+
+		// write a symlink for "b"
+		err = nw.WriteHeader(&nar.Header{
+			Path:       "b",
+			Type:       nar.TypeSymlink,
+			LinkTarget: "foo",
+		})
+		assert.NoError(t, err)
+
+		// write a symlink for "a"
+		err = nw.WriteHeader(&nar.Header{
+			Path:       "a",
+			Type:       nar.TypeSymlink,
+			LinkTarget: "foo",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("not lexicographically sorted, but the same", func(t *testing.T) {
+		var buf bytes.Buffer
+		nw, err := nar.NewWriter(&buf)
+		assert.NoError(t, err)
+
+		// write a directory node
+		err = nw.WriteHeader(&nar.Header{
+			Path: "",
+			Type: nar.TypeDirectory,
+		})
+		assert.NoError(t, err)
+
+		// write a symlink for "a"
+		err = nw.WriteHeader(&nar.Header{
+			Path:       "a",
+			Type:       nar.TypeSymlink,
+			LinkTarget: "foo",
+		})
+		assert.NoError(t, err)
+
+		// write a symlink for "a"
+		err = nw.WriteHeader(&nar.Header{
+			Path:       "a",
+			Type:       nar.TypeSymlink,
+			LinkTarget: "foo",
+		})
+		assert.Error(t, err)
+	})
+}

--- a/pkg/wire/bytes_writer.go
+++ b/pkg/wire/bytes_writer.go
@@ -1,0 +1,59 @@
+package wire
+
+import (
+	"fmt"
+	"io"
+)
+
+var _ io.WriteCloser = &BytesWriter{}
+
+// BytesWriter implements writing bytes fields.
+// It'll return a io.WriteCloser that can be written to.
+// On Write(), it'll verify we don't write more than was initially specified.
+// On Close(), it'll verify exactly the previously specified number of bytes were written,
+// then write any necessary padding.
+type BytesWriter struct {
+	w            io.Writer
+	bytesWritten uint64 // the number of bytes written so far
+	totalLength  uint64 // the expected length of the contents, without padding
+
+}
+
+func NewBytesWriter(w io.Writer, contentLength uint64) (*BytesWriter, error) {
+	// write the size field
+	n := contentLength
+	if err := WriteUint64(w, n); err != nil {
+		return nil, err
+	}
+
+	bytesWriter := &BytesWriter{
+		w:            w,
+		bytesWritten: 0,
+		totalLength:  contentLength,
+	}
+
+	return bytesWriter, nil
+}
+
+func (bw *BytesWriter) Write(p []byte) (n int, err error) {
+	l := len(p)
+
+	if bw.bytesWritten+uint64(l) > bw.totalLength {
+		return 0, fmt.Errorf("maximum number of bytes exceeded")
+	}
+
+	bytesWritten, err := bw.w.Write(p)
+	bw.bytesWritten += uint64(bytesWritten)
+
+	return bytesWritten, err
+}
+
+// Close ensures the previously specified number of bytes were written, then writes padding.
+func (bw *BytesWriter) Close() error {
+	if bw.bytesWritten != bw.totalLength {
+		return fmt.Errorf("wrote %v bytes in total, but expected %v", bw.bytesWritten, bw.totalLength)
+	}
+
+	// write padding
+	return writePadding(bw.w, bw.totalLength)
+}

--- a/pkg/wire/bytes_writer.go
+++ b/pkg/wire/bytes_writer.go
@@ -13,10 +13,10 @@ var _ io.WriteCloser = &BytesWriter{}
 // On Close(), it'll verify exactly the previously specified number of bytes were written,
 // then write any necessary padding.
 type BytesWriter struct {
-	w            io.Writer
-	bytesWritten uint64 // the number of bytes written so far
-	totalLength  uint64 // the expected length of the contents, without padding
-
+	w              io.Writer
+	bytesWritten   uint64 // the number of bytes written so far
+	totalLength    uint64 // the expected length of the contents, without padding
+	paddingWritten bool
 }
 
 func NewBytesWriter(w io.Writer, contentLength uint64) (*BytesWriter, error) {
@@ -27,9 +27,10 @@ func NewBytesWriter(w io.Writer, contentLength uint64) (*BytesWriter, error) {
 	}
 
 	bytesWriter := &BytesWriter{
-		w:            w,
-		bytesWritten: 0,
-		totalLength:  contentLength,
+		w:              w,
+		bytesWritten:   0,
+		totalLength:    contentLength,
+		paddingWritten: false,
 	}
 
 	return bytesWriter, nil
@@ -50,10 +51,22 @@ func (bw *BytesWriter) Write(p []byte) (n int, err error) {
 
 // Close ensures the previously specified number of bytes were written, then writes padding.
 func (bw *BytesWriter) Close() error {
+	// if we already closed once, don't close again
+	if bw.paddingWritten {
+		return nil
+	}
+
 	if bw.bytesWritten != bw.totalLength {
 		return fmt.Errorf("wrote %v bytes in total, but expected %v", bw.bytesWritten, bw.totalLength)
 	}
 
 	// write padding
-	return writePadding(bw.w, bw.totalLength)
+	err := writePadding(bw.w, bw.totalLength)
+	if err != nil {
+		return err
+	}
+
+	bw.paddingWritten = true
+
+	return nil
 }

--- a/pkg/wire/write_test.go
+++ b/pkg/wire/write_test.go
@@ -86,6 +86,11 @@ func TestBytesWriter10Bytes(t *testing.T) {
 	err = bw.Close()
 	assert.NoError(t, err)
 
+	// closing again shouldn't panic
+	assert.NotPanics(t, func() {
+		bw.Close()
+	})
+
 	assert.Equal(t, wire10Bytes, buf.Bytes())
 }
 

--- a/pkg/wire/write_test.go
+++ b/pkg/wire/write_test.go
@@ -50,3 +50,67 @@ func TestWriteString(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, wireStringFoo, buf.Bytes())
 }
+
+func TestBytesWriter8Bytes(t *testing.T) {
+	var buf bytes.Buffer
+
+	bw, err := wire.NewBytesWriter(&buf, uint64(len(contents8Bytes)))
+	assert.NoError(t, err)
+
+	n, err := bw.Write(contents8Bytes[:4])
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n)
+	n, err = bw.Write(contents8Bytes[4:])
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n)
+
+	err = bw.Close()
+	assert.NoError(t, err)
+
+	assert.Equal(t, wire8Bytes, buf.Bytes())
+}
+
+func TestBytesWriter10Bytes(t *testing.T) {
+	var buf bytes.Buffer
+
+	bw, err := wire.NewBytesWriter(&buf, uint64(len(contents10Bytes)))
+	assert.NoError(t, err)
+
+	n, err := bw.Write(contents10Bytes[:4])
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n)
+	n, err = bw.Write(contents10Bytes[4:])
+	assert.NoError(t, err)
+	assert.Equal(t, 6, n)
+
+	err = bw.Close()
+	assert.NoError(t, err)
+
+	assert.Equal(t, wire10Bytes, buf.Bytes())
+}
+
+func TestBytesWriterError(t *testing.T) {
+	var buf bytes.Buffer
+
+	// initialize a bytes writer with a len of 9
+	bw, err := wire.NewBytesWriter(&buf, 9)
+	assert.NoError(t, err)
+
+	// try to write 10 bytes into it
+	_, err = bw.Write(contents10Bytes)
+	assert.Error(t, err)
+
+	buf.Reset()
+
+	// initialize a bytes writer with a len of 11
+	bw, err = wire.NewBytesWriter(&buf, 11)
+	assert.NoError(t, err)
+
+	// write 10 bytes into it
+	n, err := bw.Write(contents10Bytes)
+	assert.NoError(t, err)
+	assert.Equal(t, 10, n)
+
+	err = bw.Close()
+	assert.Error(t, err, "closing should fail, as one byte is still missing")
+}


### PR DESCRIPTION
This introduces the writer component for `pkg/nar`, with a similar interface to `archive/tar`.

It also increases test coverage for the NAR reader, thanks to some of the fixtures created for the NAR writer tests.

There's probably some more places where we could have more test coverage, mostly premature closing of the NAR readers and writers, but this can be done as a follow-up.