### PR TITLE
fix(pkg/nar): loosen node name restrictions

### DIFF
--- a/pkg/nar/header.go
+++ b/pkg/nar/header.go
@@ -1,7 +1,9 @@
 package nar
 
 import (
+	"fmt"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -13,6 +15,44 @@ type Header struct {
 	LinkTarget string   // Target of symlink (valid for TypeSymlink)
 	Size       int64    // Logical file size in bytes
 	Executable bool     // Set to true for files that are executable
+}
+
+// Validate does some consistency checking of the header structure, such as
+// checking for valid paths and inconsistent fields, and returns an error if it
+// fails validation.
+func (h *Header) Validate() error {
+	// Path may not start with a /, and may not contain null bytes
+	if len(h.Path) > 1 {
+		if h.Path[:1] == "/" {
+			return fmt.Errorf("path %v starts with a /", h.Path)
+		}
+
+		if strings.ContainsAny(h.Path, "\u0000") {
+			return fmt.Errorf("path contains null bytes")
+		}
+	}
+
+	// Regular files and directories may not have LinkTarget set.
+	if h.Type == TypeRegular || h.Type == TypeDirectory {
+		if h.LinkTarget != "" {
+			if h.LinkTarget != "" {
+				return fmt.Errorf("type is %v, but LinkTarget is not empty", h.Type.String())
+			}
+		}
+	}
+
+	// Directories and Symlinks may not have Size and Executable set.
+	if h.Type == TypeDirectory || h.Type == TypeSymlink {
+		if h.Size != 0 {
+			return fmt.Errorf("type is %v, but Size is not 0", h.Type.String())
+		}
+
+		if h.Executable {
+			return fmt.Errorf("type is %v, but Executable is true", h.Type.String())
+		}
+	}
+
+	return nil
 }
 
 // FileInfo returns an os.FileInfo for the Header.

--- a/pkg/nar/header.go
+++ b/pkg/nar/header.go
@@ -35,9 +35,7 @@ func (h *Header) Validate() error {
 	// Regular files and directories may not have LinkTarget set.
 	if h.Type == TypeRegular || h.Type == TypeDirectory {
 		if h.LinkTarget != "" {
-			if h.LinkTarget != "" {
-				return fmt.Errorf("type is %v, but LinkTarget is not empty", h.Type.String())
-			}
+			return fmt.Errorf("type is %v, but LinkTarget is not empty", h.Type.String())
 		}
 	}
 

--- a/pkg/nar/header.go
+++ b/pkg/nar/header.go
@@ -50,6 +50,13 @@ func (h *Header) Validate() error {
 		}
 	}
 
+	// Symlinks need to specify a target.
+	if h.Type == TypeSymlink {
+		if h.LinkTarget == "" {
+			return fmt.Errorf("type is symlink, but LinkTarget is empty")
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/nar/header_test.go
+++ b/pkg/nar/header_test.go
@@ -1,0 +1,66 @@
+package nar_test
+
+import (
+	"testing"
+
+	"github.com/nix-community/go-nix/pkg/nar"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeaderValidate(t *testing.T) {
+	headerRegular := &nar.Header{
+		Path:       "foo/bar",
+		Type:       nar.TypeRegular,
+		LinkTarget: "",
+		Size:       0,
+		Executable: false,
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		vHeader := *headerRegular
+		assert.NoError(t, vHeader.Validate())
+	})
+
+	t.Run("invalid path", func(t *testing.T) {
+		invHeader := *headerRegular
+		invHeader.Path = "/foo/bar"
+		assert.Error(t, invHeader.Validate())
+
+		invHeader.Path = "foo/bar\000/"
+		assert.Error(t, invHeader.Validate())
+	})
+
+	t.Run("LinkTarget set on regulars or directories", func(t *testing.T) {
+		invHeader := *headerRegular
+		invHeader.LinkTarget = "foo"
+
+		assert.Error(t, invHeader.Validate())
+
+		invHeader.Type = nar.TypeDirectory
+		assert.Error(t, invHeader.Validate())
+	})
+
+	t.Run("Size set on directories or symlinks", func(t *testing.T) {
+		invHeader := *headerRegular
+		invHeader.Type = nar.TypeDirectory
+		invHeader.Size = 1
+		assert.Error(t, invHeader.Validate())
+
+		invHeader = *headerRegular
+		invHeader.Type = nar.TypeSymlink
+		invHeader.Size = 1
+		assert.Error(t, invHeader.Validate())
+	})
+
+	t.Run("Executable set on directories or symlinks", func(t *testing.T) {
+		invHeader := *headerRegular
+		invHeader.Type = nar.TypeDirectory
+		invHeader.Executable = true
+		assert.Error(t, invHeader.Validate())
+
+		invHeader = *headerRegular
+		invHeader.Type = nar.TypeSymlink
+		invHeader.Executable = true
+		assert.Error(t, invHeader.Validate())
+	})
+}

--- a/pkg/nar/header_test.go
+++ b/pkg/nar/header_test.go
@@ -63,4 +63,10 @@ func TestHeaderValidate(t *testing.T) {
 		invHeader.Executable = true
 		assert.Error(t, invHeader.Validate())
 	})
+
+	t.Run("No LinkTarget set on symlinks", func(t *testing.T) {
+		invHeader := *headerRegular
+		invHeader.Type = nar.TypeSymlink
+		assert.Error(t, invHeader.Validate())
+	})
 }

--- a/pkg/nar/ls/list.go
+++ b/pkg/nar/ls/list.go
@@ -36,9 +36,7 @@ func validateNode(node *Node) error {
 		// Regular files and directories may not have LinkTarget set.
 		if node.Type == nar.TypeRegular || node.Type == nar.TypeDirectory {
 			if node.LinkTarget != "" {
-				if node.LinkTarget != "" {
-					return fmt.Errorf("type is %v, but LinkTarget is not empty", node.Type.String())
-				}
+				return fmt.Errorf("type is %v, but LinkTarget is not empty", node.Type.String())
 			}
 		}
 

--- a/pkg/nar/ls/list.go
+++ b/pkg/nar/ls/list.go
@@ -19,7 +19,7 @@ type Node struct {
 	Type       nar.NodeType    `json:"type"`
 	Entries    map[string]Node `json:"entries"`
 	Size       int64           `json:"size"`
-	Target     string          `json:"target"`
+	LinkTarget string          `json:"target"`
 	Executable bool            `json:"executable"`
 	NAROffset  int64           `json:"narOffset"`
 }

--- a/pkg/nar/ls/list.go
+++ b/pkg/nar/ls/list.go
@@ -16,12 +16,12 @@ type Root struct {
 
 // Node represents one of the entries in a .ls file.
 type Node struct {
-	Type       nar.NodeType    `json:"type"`
-	Entries    map[string]Node `json:"entries"`
-	Size       int64           `json:"size"`
-	LinkTarget string          `json:"target"`
-	Executable bool            `json:"executable"`
-	NAROffset  int64           `json:"narOffset"`
+	Type       nar.NodeType     `json:"type"`
+	Entries    map[string]*Node `json:"entries"`
+	Size       int64            `json:"size"`
+	LinkTarget string           `json:"target"`
+	Executable bool             `json:"executable"`
+	NAROffset  int64            `json:"narOffset"`
 }
 
 // validateNode runs some consistency checks on a node and all its child
@@ -54,7 +54,7 @@ func validateNode(node *Node) error {
 		}
 
 		// verify children
-		err := validateNode(&v)
+		err := validateNode(v)
 		if err != nil {
 			return err
 		}

--- a/pkg/nar/ls/list.go
+++ b/pkg/nar/ls/list.go
@@ -51,6 +51,13 @@ func validateNode(node *Node) error {
 			}
 		}
 
+		// Symlinks need to specify a target.
+		if node.Type == nar.TypeSymlink {
+			if node.LinkTarget == "" {
+				return fmt.Errorf("type is symlink, but LinkTarget is empty")
+			}
+		}
+
 		// verify children
 		err := validateNode(v)
 		if err != nil {

--- a/pkg/nar/ls/list.go
+++ b/pkg/nar/ls/list.go
@@ -24,6 +24,45 @@ type Node struct {
 	NAROffset  int64           `json:"narOffset"`
 }
 
+// validateNode runs some consistency checks on a node and all its child
+// entries. It returns an error on failure.
+func validateNode(node *Node) error {
+	// ensure the name of each entry is valid
+	for k, v := range node.Entries {
+		if !nar.IsValidNodeName(k) {
+			return fmt.Errorf("invalid entry name: %v", k)
+		}
+
+		// Regular files and directories may not have LinkTarget set.
+		if node.Type == nar.TypeRegular || node.Type == nar.TypeDirectory {
+			if node.LinkTarget != "" {
+				if node.LinkTarget != "" {
+					return fmt.Errorf("type is %v, but LinkTarget is not empty", node.Type.String())
+				}
+			}
+		}
+
+		// Directories and Symlinks may not have Size and Executable set.
+		if node.Type == nar.TypeDirectory || node.Type == nar.TypeSymlink {
+			if node.Size != 0 {
+				return fmt.Errorf("type is %v, but Size is not 0", node.Type.String())
+			}
+
+			if node.Executable {
+				return fmt.Errorf("type is %v, but Executable is true", node.Type.String())
+			}
+		}
+
+		// verify children
+		err := validateNode(&v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // ParseLS parses the NAR .ls file format.
 // It returns a tree-like structure for all the entries.
 func ParseLS(r io.Reader) (*Root, error) {
@@ -39,6 +78,12 @@ func ParseLS(r io.Reader) (*Root, error) {
 
 	if root.Version != 1 {
 		return nil, fmt.Errorf("invalid version %d", root.Version)
+	}
+
+	// ensure the nodes are valid
+	err = validateNode(&root.Root)
+	if err != nil {
+		return nil, err
 	}
 
 	return &root, err

--- a/pkg/nar/ls/list_test.go
+++ b/pkg/nar/ls/list_test.go
@@ -40,10 +40,10 @@ func TestLS(t *testing.T) {
 		Version: 1,
 		Root: ls.Node{
 			Type: nar.TypeDirectory,
-			Entries: map[string]ls.Node{
+			Entries: map[string]*ls.Node{
 				"bin": {
 					Type: nar.TypeDirectory,
-					Entries: map[string]ls.Node{
+					Entries: map[string]*ls.Node{
 						"curl": {
 							Type:       nar.TypeRegular,
 							Size:       182520,

--- a/pkg/nar/reader.go
+++ b/pkg/nar/reader.go
@@ -311,8 +311,8 @@ func (nr *Reader) Next() (*Header, error) {
 
 	// return either an error or headers
 	select {
-	case header := <-nr.headers:
-		return header, nil
+	case hdr := <-nr.headers:
+		return hdr, nil
 	case err := <-nr.errors:
 		if err != nil {
 			// blow fuse

--- a/pkg/nar/reader.go
+++ b/pkg/nar/reader.go
@@ -258,8 +258,8 @@ func (nr *Reader) parseNode(path string) error {
 					return err
 				}
 
-				// validate the name matches NameRe (no slashes etc.)
-				if !NodeNameRegexp.MatchString(currentToken) {
+				// ensure the name is valid
+				if !isValidNodeName(currentToken) {
 					return fmt.Errorf("name `%v` is invalid", currentToken)
 				}
 

--- a/pkg/nar/reader.go
+++ b/pkg/nar/reader.go
@@ -259,7 +259,7 @@ func (nr *Reader) parseNode(path string) error {
 				}
 
 				// ensure the name is valid
-				if !isValidNodeName(currentToken) {
+				if !IsValidNodeName(currentToken) {
 					return fmt.Errorf("name `%v` is invalid", currentToken)
 				}
 

--- a/pkg/nar/types.go
+++ b/pkg/nar/types.go
@@ -1,12 +1,5 @@
 package nar
 
-import (
-	"fmt"
-	"regexp"
-
-	"github.com/nix-community/go-nix/pkg/nixpath"
-)
-
 const narVersionMagic1 = "nix-archive-1"
 
 // Enum of all the node types possible.
@@ -20,8 +13,6 @@ const (
 	// TypeSymlink represents a file symlink.
 	TypeSymlink = NodeType("symlink")
 )
-
-var NodeNameRegexp = regexp.MustCompile(fmt.Sprintf("^%v$", nixpath.NameRe))
 
 func (t NodeType) String() string {
 	return string(t)

--- a/pkg/nar/util.go
+++ b/pkg/nar/util.go
@@ -1,0 +1,9 @@
+package nar
+
+import "strings"
+
+// isValidNodeName checks the name of a node
+// it may not contain null bytes or slashes.
+func isValidNodeName(nodeName string) bool {
+	return !strings.Contains(nodeName, "/") && !strings.ContainsAny(nodeName, "\000/")
+}

--- a/pkg/nar/util.go
+++ b/pkg/nar/util.go
@@ -5,5 +5,5 @@ import "strings"
 // isValidNodeName checks the name of a node
 // it may not contain null bytes or slashes.
 func isValidNodeName(nodeName string) bool {
-	return !strings.Contains(nodeName, "/") && !strings.ContainsAny(nodeName, "\000/")
+	return !strings.Contains(nodeName, "/") && !strings.ContainsAny(nodeName, "\u0000")
 }

--- a/pkg/nar/util.go
+++ b/pkg/nar/util.go
@@ -2,8 +2,8 @@ package nar
 
 import "strings"
 
-// isValidNodeName checks the name of a node
+// IsValidNodeName checks the name of a node
 // it may not contain null bytes or slashes.
-func isValidNodeName(nodeName string) bool {
+func IsValidNodeName(nodeName string) bool {
 	return !strings.Contains(nodeName, "/") && !strings.ContainsAny(nodeName, "\u0000")
 }

--- a/pkg/nar/writer.go
+++ b/pkg/nar/writer.go
@@ -287,6 +287,10 @@ func (nw *Writer) emitNode(currentHeader *Header) (*Header, error) {
 // the current file is not fully written, then this returns an error. This
 // implicitly flushes any padding necessary before writing the header.
 func (nw *Writer) WriteHeader(hdr *Header) error {
+	if err := hdr.Validate(); err != nil {
+		return fmt.Errorf("unable to write header: %w", err)
+	}
+
 	nw.headers <- hdr
 	select {
 	case err := <-nw.errors:

--- a/pkg/nar/writer.go
+++ b/pkg/nar/writer.go
@@ -233,7 +233,7 @@ func (nw *Writer) emitNode(currentHeader *Header) (*Header, error) {
 
 		// ensure the name is valid. At this point, there should be no more slashes,
 		// as we already recursed up.
-		if !isValidNodeName(nodeName) {
+		if !IsValidNodeName(nodeName) {
 			return nil, fmt.Errorf("name `%v` is invalid, as it contains a slash", nodeName)
 		}
 

--- a/pkg/nar/writer.go
+++ b/pkg/nar/writer.go
@@ -206,7 +206,8 @@ func (nw *Writer) emitNode(currentHeader *Header) (*Header, error) {
 			)
 		}
 
-		// calculate the relative path between the previous and now-read header
+		// calculate the relative path between the previous and now-read header,
+		// which will become the new node name.
 		nodeName, err := filepath.Rel(currentHeader.Path, nextHeader.Path)
 		if err != nil {
 			return nil, err
@@ -230,10 +231,10 @@ func (nw *Writer) emitNode(currentHeader *Header) (*Header, error) {
 			return nil, fmt.Errorf("received descending path %v, but we're a %v", nextHeader.Path, currentHeader.Type.String())
 		}
 
-		// Each directory needs to be its own node,
-		// so no slashes in the nodeName / relative path allowed.
-		if !NodeNameRegexp.MatchString(nodeName) {
-			return nil, fmt.Errorf("name %v is invalid", nodeName)
+		// ensure the name is valid. At this point, there should be no more slashes,
+		// as we already recursed up.
+		if !isValidNodeName(nodeName) {
+			return nil, fmt.Errorf("name `%v` is invalid, as it contains a slash", nodeName)
 		}
 
 		// write the entry keyword

--- a/pkg/nar/writer_test.go
+++ b/pkg/nar/writer_test.go
@@ -109,9 +109,13 @@ func TestWriterSmoketest(t *testing.T) {
 	contents := [][]byte{}
 
 	for {
-		hdr, e := nr.Next()
-		if e == io.EOF {
-			break
+		hdr, err := nr.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+
+			panic("unexpected error while reading in file")
 		}
 
 		headers = append(headers, hdr)


### PR DESCRIPTION
Nix paths have much stronger requirements than regular paths. The only
thing we don't want to see is a / in the node name.

cc: @puckipedia