### PR TITLE
Introduce cmd/gonix, pkg/nar.DumpPath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-tests/.minio.sys/
-tests/nar/
+/gonix

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Methods to serialize and deserialize some of the hashes used in nix code and
 
 ## `pkg/nar`
 A Nix ARchive (NAR) file Reader and Writer, with an interface similar to
-`archive/tar` from the stdlib
+`archive/tar` from the stdlib, as well as a `DumpPath` method, which
+will assemble a NAR representation of a local file system path.
 
 ## `pkg/nar/ls`
 A parser for .ls files (providing an index for .nar files)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 This repository holds a bunch of experiments written in Go.
 
+## `cmd/gonix`
+A command line entrypoint called `gonix`, currently implementing the nar
+{cat,dump-path,ls} commands.
+
+They're not meant to be 100% compatible, but are documented in the `--help`
+output.
+
 ## `pkg/derivation`
 A parser for Nix `.drv` files
 

--- a/cmd/gonix/main.go
+++ b/cmd/gonix/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/alecthomas/kong"
+	"github.com/nix-community/go-nix/cmd/gonix/nar"
+)
+
+// nolint:gochecknoglobals
+var cli struct {
+	Nar nar.Cmd `kong:"cmd,name='nar',help='Create or inspect NAR files'"`
+}
+
+func main() {
+	ctx := kong.Parse(&cli)
+	// Call the Run() method of the selected parsed command.
+	err := ctx.Run()
+
+	ctx.FatalIfErrorf(err)
+}

--- a/cmd/gonix/nar/cat.go
+++ b/cmd/gonix/nar/cat.go
@@ -1,0 +1,55 @@
+package nar
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/nix-community/go-nix/pkg/nar"
+)
+
+type CatCmd struct {
+	Nar  string `kong:"arg,type='existingfile',help='Path to the NAR'"`
+	Path string `kong:"arg,type='string',help='Path inside the NAR, without leading slash'"`
+}
+
+func (cmd *CatCmd) Run() error {
+	f, err := os.Open(cmd.Nar)
+	if err != nil {
+		return err
+	}
+
+	nr, err := nar.NewReader(f)
+	if err != nil {
+		return err
+	}
+
+	for {
+		hdr, err := nr.Next()
+		if err != nil {
+			// io.EOF means we didn't find the requested path
+			if err == io.EOF {
+				return fmt.Errorf("requested path not found")
+			}
+			// relay other errors
+			return err
+		}
+
+		if hdr.Path == cmd.Path {
+			// we can't cat directories and symlinks
+			if hdr.Type != nar.TypeRegular {
+				return fmt.Errorf("unable to cat non-regular file")
+			}
+
+			w := bufio.NewWriter(os.Stdout)
+
+			_, err := io.Copy(w, nr)
+			if err != nil {
+				return err
+			}
+
+			return w.Flush()
+		}
+	}
+}

--- a/cmd/gonix/nar/cmd.go
+++ b/cmd/gonix/nar/cmd.go
@@ -1,0 +1,7 @@
+package nar
+
+type Cmd struct {
+	Cat      CatCmd      `kong:"cmd,name='cat',help='Print the contents of a file inside a NAR file'"`
+	DumpPath DumpPathCmd `kong:"cmd,name='dump-path',help='Serialise a path to stdout in NAR format'"`
+	Ls       LsCmd       `kong:"cmd,name='ls',help='Show information about a path inside a NAR file'"`
+}

--- a/cmd/gonix/nar/dump.go
+++ b/cmd/gonix/nar/dump.go
@@ -2,11 +2,7 @@ package nar
 
 import (
 	"bufio"
-	"fmt"
-	"io"
 	"os"
-	"path/filepath"
-	"syscall"
 
 	"github.com/nix-community/go-nix/pkg/nar"
 )
@@ -15,115 +11,11 @@ type DumpPathCmd struct {
 	Path string `kong:"arg,type:'path',help:'The path to dump'"`
 }
 
-func dumppath(nw *nar.Writer, path string, subpath string) error {
-	// assemble the full path.
-	p := filepath.Join(path, subpath)
-
-	// peek at the path
-	fi, err := os.Lstat(p)
-	if err != nil {
-		return err
-	}
-
-	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
-		linkTarget, err := os.Readlink(p)
-		if err != nil {
-			return err
-		}
-
-		// write the symlink node
-		err = nw.WriteHeader(&nar.Header{
-			Path:       subpath,
-			Type:       nar.TypeSymlink,
-			LinkTarget: linkTarget,
-		})
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}
-
-	if fi.IsDir() {
-		// write directory node
-		err := nw.WriteHeader(&nar.Header{
-			Path: subpath,
-			Type: nar.TypeDirectory,
-		})
-		if err != nil {
-			return err
-		}
-
-		// look at the children
-		files, err := os.ReadDir(filepath.Join(path, subpath))
-		if err != nil {
-			return err
-		}
-
-		// loop over all elements
-		for _, file := range files {
-			err := dumppath(nw, path, filepath.Join(subpath, file.Name()))
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
-	}
-
-	if fi.Mode().IsRegular() {
-		// write regular node
-		err := nw.WriteHeader(&nar.Header{
-			Path: subpath,
-			Type: nar.TypeRegular,
-			Size: fi.Size(),
-			// If it's executable by the user, it'll become executable.
-			// This matches nix's dump() function behaviour.
-			Executable: fi.Mode()&syscall.S_IXUSR != 0,
-		})
-		if err != nil {
-			return err
-		}
-
-		// open the file
-		f, err := os.Open(p)
-		if err != nil {
-			return err
-		}
-
-		// read in contents
-		n, err := io.Copy(nw, f)
-		if err != nil {
-			return err
-		}
-
-		// check if read bytes matches fi.Size()
-		if n != fi.Size() {
-			return fmt.Errorf("read %v, expected %v bytes while reading %v", n, fi.Size(), p)
-		}
-
-		return nil
-	}
-
-	return fmt.Errorf("invalid mode for file %v", p)
-}
-
 func (cmd *DumpPathCmd) Run() error {
 	// grab stdout
 	w := bufio.NewWriter(os.Stdout)
 
-	// initialize the nar writer
-	nw, err := nar.NewWriter(w)
-	if err != nil {
-		return err
-	}
-
-	err = dumppath(nw, cmd.Path, "")
-	if err != nil {
-		return err
-	}
-
-	err = nw.Close()
+	err := nar.DumpPath(w, cmd.Path)
 	if err != nil {
 		return err
 	}

--- a/cmd/gonix/nar/dump.go
+++ b/cmd/gonix/nar/dump.go
@@ -1,0 +1,132 @@
+package nar
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/nix-community/go-nix/pkg/nar"
+)
+
+type DumpPathCmd struct {
+	Path string `kong:"arg,type:'path',help:'The path to dump'"`
+}
+
+func dumppath(nw *nar.Writer, path string, subpath string) error {
+	// assemble the full path.
+	p := filepath.Join(path, subpath)
+
+	// peek at the path
+	fi, err := os.Lstat(p)
+	if err != nil {
+		return err
+	}
+
+	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+		linkTarget, err := os.Readlink(p)
+		if err != nil {
+			return err
+		}
+
+		// write the symlink node
+		err = nw.WriteHeader(&nar.Header{
+			Path:       subpath,
+			Type:       nar.TypeSymlink,
+			LinkTarget: linkTarget,
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	if fi.IsDir() {
+		// write directory node
+		err := nw.WriteHeader(&nar.Header{
+			Path: subpath,
+			Type: nar.TypeDirectory,
+		})
+		if err != nil {
+			return err
+		}
+
+		// look at the children
+		files, err := os.ReadDir(filepath.Join(path, subpath))
+		if err != nil {
+			return err
+		}
+
+		// loop over all elements
+		for _, file := range files {
+			err := dumppath(nw, path, filepath.Join(subpath, file.Name()))
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	if fi.Mode().IsRegular() {
+		// write regular node
+		err := nw.WriteHeader(&nar.Header{
+			Path: subpath,
+			Type: nar.TypeRegular,
+			Size: fi.Size(),
+			// If it's executable by the user, it'll become executable.
+			// This matches nix's dump() function behaviour.
+			Executable: fi.Mode()&syscall.S_IXUSR != 0,
+		})
+		if err != nil {
+			return err
+		}
+
+		// open the file
+		f, err := os.Open(p)
+		if err != nil {
+			return err
+		}
+
+		// read in contents
+		n, err := io.Copy(nw, f)
+		if err != nil {
+			return err
+		}
+
+		// check if read bytes matches fi.Size()
+		if n != fi.Size() {
+			return fmt.Errorf("read %v, expected %v bytes while reading %v", n, fi.Size(), p)
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("invalid mode for file %v", p)
+}
+
+func (cmd *DumpPathCmd) Run() error {
+	// grab stdout
+	w := bufio.NewWriter(os.Stdout)
+
+	// initialize the nar writer
+	nw, err := nar.NewWriter(w)
+	if err != nil {
+		return err
+	}
+
+	err = dumppath(nw, cmd.Path, "")
+	if err != nil {
+		return err
+	}
+
+	err = nw.Close()
+	if err != nil {
+		return err
+	}
+
+	return w.Flush()
+}

--- a/cmd/gonix/nar/ls.go
+++ b/cmd/gonix/nar/ls.go
@@ -1,0 +1,89 @@
+package nar
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/nix-community/go-nix/pkg/nar"
+)
+
+type LsCmd struct {
+	Nar       string `kong:"arg,type:'existingfile',help='Path to the NAR'"`
+	Path      string `kong:"arg,optional,type='string',default='',help='Path inside the NAR, without leading slash'"`
+	Recursive bool   `kong:"short='R',help='Whether to list recursively, or only the current level.'"`
+}
+
+// headerLineString returns a one-line string describing a header.
+// hdr.Validate() is assumed to be true.
+func headerLineString(hdr *nar.Header) string {
+	var sb strings.Builder
+
+	sb.WriteString(hdr.FileInfo().Mode().String())
+	sb.WriteString(" ")
+
+	// write name. In case of an empty path, write a "."
+	if hdr.Path == "" {
+		sb.WriteString(".")
+	} else {
+		sb.WriteString(hdr.Path)
+	}
+
+	// if regular file, show size in parantheses. We don't bother about aligning it nicely,
+	// as that'd require reading in all headers first before printing them out.
+	if hdr.Size > 0 {
+		sb.WriteString(fmt.Sprintf(" (%v bytes)", hdr.Size))
+	}
+
+	// if LinkTarget, show it
+	if hdr.LinkTarget != "" {
+		sb.WriteString(" -> ")
+		sb.WriteString(hdr.LinkTarget)
+	}
+
+	sb.WriteString("\n")
+
+	return sb.String()
+}
+
+func (cmd *LsCmd) Run() error {
+	f, err := os.Open(cmd.Nar)
+	if err != nil {
+		return err
+	}
+
+	nr, err := nar.NewReader(f)
+	if err != nil {
+		return err
+	}
+
+	for {
+		hdr, err := nr.Next()
+		if err != nil {
+			// io.EOF means we're done
+			if err == io.EOF {
+				return nil
+			}
+			// relay other errors
+			return err
+		}
+
+		// if the yielded path starts with the path specified
+		if strings.HasPrefix(hdr.Path, cmd.Path) {
+			remainder := hdr.Path[len(cmd.Path):]
+			// If recursive was requested, return all these elements.
+			// Else, look at the remainder - There may be no other slashes.
+			if cmd.Recursive || !strings.Contains(remainder, "/") {
+				// fmt.Printf("%v type %v\n", hdr.Type, hdr.Path)
+				print(headerLineString(hdr))
+			}
+		} else {
+			// We can exit early as soon as we receive a header whose path doesn't have the prefix we're searching for,
+			// and the path is lexicographically bigger than our search prefix
+			if hdr.Path > cmd.Path {
+				return nil
+			}
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/nix-community/go-nix
 go 1.15
 
 require (
+	github.com/alecthomas/kong v0.5.0
 	github.com/alecthomas/participle/v2 v2.0.0-alpha7
-	github.com/alecthomas/repr v0.0.0-20200325044227-4184120f674c // indirect
 	github.com/google/go-cmp v0.5.5
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/stretchr/testify v1.6.1
+	github.com/stretchr/testify v1.7.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,10 @@
+github.com/alecthomas/kong v0.5.0 h1:u8Kdw+eeml93qtMZ04iei0CFYve/WPcA5IFh+9wSskE=
+github.com/alecthomas/kong v0.5.0/go.mod h1:uzxf/HUh0tj43x1AyJROl3JT7SgsZ5m+icOv1csRhc0=
 github.com/alecthomas/participle/v2 v2.0.0-alpha7 h1:cK4vjj0VSgb3lN1nuKA5F7dw+1s1pWBe5bx7nNCnN+c=
 github.com/alecthomas/participle/v2 v2.0.0-alpha7/go.mod h1:NumScqsC42o9x+dGj8/YqsIfhrIQjFEOFovxotbBirA=
 github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
-github.com/alecthomas/repr v0.0.0-20200325044227-4184120f674c h1:MVVbswUlqicyj8P/JljoocA7AyCo62gzD0O7jfvrhtE=
-github.com/alecthomas/repr v0.0.0-20200325044227-4184120f674c/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
+github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142 h1:8Uy0oSf5co/NZXje7U1z8Mpep++QJOldL2hs/sBQf48=
+github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -13,6 +15,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -20,10 +24,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -31,5 +33,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/nar/dump.go
+++ b/pkg/nar/dump.go
@@ -1,0 +1,124 @@
+package nar
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// DumpPath will serialize a path on the local file system to NAR format,
+// and write it to the passed writer.
+func DumpPath(w io.Writer, path string) error {
+	// initialize the nar writer
+	nw, err := NewWriter(w)
+	if err != nil {
+		return err
+	}
+
+	// make sure the NAR writer is always closed, so the underlying goroutine is stopped
+	defer nw.Close()
+
+	err = dumpPath(nw, path, "")
+	if err != nil {
+		return err
+	}
+
+	return nw.Close()
+}
+
+// dumpPath recursively calls itself for every node in the path.
+func dumpPath(nw *Writer, path string, subpath string) error {
+	// assemble the full path.
+	p := filepath.Join(path, subpath)
+
+	// peek at the path
+	fi, err := os.Lstat(p)
+	if err != nil {
+		return err
+	}
+
+	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+		linkTarget, err := os.Readlink(p)
+		if err != nil {
+			return err
+		}
+
+		// write the symlink node
+		err = nw.WriteHeader(&Header{
+			Path:       subpath,
+			Type:       TypeSymlink,
+			LinkTarget: linkTarget,
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	if fi.IsDir() {
+		// write directory node
+		err := nw.WriteHeader(&Header{
+			Path: subpath,
+			Type: TypeDirectory,
+		})
+		if err != nil {
+			return err
+		}
+
+		// look at the children
+		files, err := os.ReadDir(filepath.Join(path, subpath))
+		if err != nil {
+			return err
+		}
+
+		// loop over all elements
+		for _, file := range files {
+			err := dumpPath(nw, path, filepath.Join(subpath, file.Name()))
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	if fi.Mode().IsRegular() {
+		// write regular node
+		err := nw.WriteHeader(&Header{
+			Path: subpath,
+			Type: TypeRegular,
+			Size: fi.Size(),
+			// If it's executable by the user, it'll become executable.
+			// This matches nix's dump() function behaviour.
+			Executable: fi.Mode()&syscall.S_IXUSR != 0,
+		})
+		if err != nil {
+			return err
+		}
+
+		// open the file
+		f, err := os.Open(p)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		// read in contents
+		n, err := io.Copy(nw, f)
+		if err != nil {
+			return err
+		}
+
+		// check if read bytes matches fi.Size()
+		if n != fi.Size() {
+			return fmt.Errorf("read %v, expected %v bytes while reading %v", n, fi.Size(), p)
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("invalid mode for file %v", p)
+}

--- a/pkg/nar/dump_test.go
+++ b/pkg/nar/dump_test.go
@@ -1,0 +1,136 @@
+package nar_test
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/nix-community/go-nix/pkg/nar"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDumpPathEmptyDir(t *testing.T) {
+	var buf bytes.Buffer
+
+	err := nar.DumpPath(&buf, t.TempDir())
+	if assert.NoError(t, err) {
+		assert.Equal(t, genEmptyDirectoryNar(), buf.Bytes())
+	}
+}
+
+func TestDumpPathOneByteRegular(t *testing.T) {
+	t.Run("non-executable", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		p := filepath.Join(tmpDir, "a")
+
+		err := os.WriteFile(p, []byte{0x1}, os.ModePerm&syscall.S_IRUSR)
+		if err != nil {
+			panic(err)
+		}
+
+		var buf bytes.Buffer
+
+		err = nar.DumpPath(&buf, p)
+		if assert.NoError(t, err) {
+			assert.Equal(t, genOneByteRegularNar(), buf.Bytes())
+		}
+	})
+
+	t.Run("executable", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		p := filepath.Join(tmpDir, "a")
+
+		err := os.WriteFile(p, []byte{0x1}, os.ModePerm&(syscall.S_IRUSR|syscall.S_IXUSR))
+		if err != nil {
+			panic(err)
+		}
+
+		var buf bytes.Buffer
+
+		// call dump path on it again
+		err = nar.DumpPath(&buf, p)
+		if assert.NoError(t, err) {
+			// We don't have a fixture with executable bit set,
+			// so pipe the nar into a reader and check the returned first header.
+			nr, err := nar.NewReader(&buf)
+			if err != nil {
+				panic(err)
+			}
+
+			hdr, err := nr.Next()
+			if err != nil {
+				panic(err)
+			}
+			assert.True(t, hdr.Executable, "regular should be executable")
+		}
+	})
+}
+
+func TestDumpPathSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	p := filepath.Join(tmpDir, "a")
+
+	err := os.Symlink("/nix/store/somewhereelse", p)
+	if err != nil {
+		panic(err)
+	}
+
+	var buf bytes.Buffer
+
+	err = nar.DumpPath(&buf, p)
+	if assert.NoError(t, err) {
+		assert.Equal(t, genSymlinkNar(), buf.Bytes())
+	}
+}
+
+func TestDumpPathRecursion(t *testing.T) {
+	tmpDir := t.TempDir()
+	p := filepath.Join(tmpDir, "a")
+
+	err := os.WriteFile(p, []byte{0x1}, os.ModePerm&syscall.S_IRUSR)
+	if err != nil {
+		panic(err)
+	}
+
+	var buf bytes.Buffer
+
+	err = nar.DumpPath(&buf, tmpDir)
+	if assert.NoError(t, err) {
+		// We don't have a fixture for the created path
+		// so pipe the nar into a reader and check the headers returned.
+		nr, err := nar.NewReader(&buf)
+		if err != nil {
+			panic(err)
+		}
+
+		// read in first node
+		hdr, err := nr.Next()
+		assert.NoError(t, err)
+		assert.Equal(t, &nar.Header{
+			Path: "",
+			Type: nar.TypeDirectory,
+		}, hdr)
+
+		// read in second node
+		hdr, err = nr.Next()
+		assert.NoError(t, err)
+		assert.Equal(t, &nar.Header{
+			Path: "a",
+			Type: nar.TypeRegular,
+			Size: 1,
+		}, hdr)
+
+		// read in contents
+		contents, err := ioutil.ReadAll(nr)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte{0x1}, contents)
+
+		// we should be done
+		_, err = nr.Next()
+		assert.Equal(t, io.EOF, err)
+	}
+}

--- a/pkg/nar/writer_test.go
+++ b/pkg/nar/writer_test.go
@@ -17,6 +17,10 @@ func TestWriterEmpty(t *testing.T) {
 
 	// calling close on an empty NAR is an error, as it'd be invalid.
 	assert.Error(t, nw.Close())
+
+	assert.NotPanics(t, func() {
+		nw.Close()
+	}, "closing a second time, after the first one failed shouldn't panic")
 }
 
 func TestWriterEmptyDirectory(t *testing.T) {
@@ -36,6 +40,10 @@ func TestWriterEmptyDirectory(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, genEmptyDirectoryNar(), buf.Bytes())
+
+	assert.NotPanics(t, func() {
+		nw.Close()
+	}, "closing a second time shouldn't panic")
 }
 
 // TestWriterOneByteRegular writes a NAR only containing a single file at the root.


### PR DESCRIPTION
This introduces a CLI endpoint, exposing some of the functionality
provided inside pkg/.
    
Right now, it only exposes the functionality provided by the `nix nar
{cat,dump-path,ls}` commands in Nix, but its structure makes adding more
commands easy.

The logic used in the `nar dump-path` command was generic enough to be
moved to `pkg/nar`, and some tests were added.

`pkg/nar/header.go` received some love, and is now using less hardcoded
magic numbers. The `pkg/nar.Header`'s `FileInfo().Mode()` is getting used
to render the permission string in the `nar ls` subcommand.