### PR TITLE
feat(pkg/nar): show a leading slash

### DIFF
--- a/cmd/gonix/nar/cat.go
+++ b/cmd/gonix/nar/cat.go
@@ -11,7 +11,7 @@ import (
 
 type CatCmd struct {
 	Nar  string `kong:"arg,type='existingfile',help='Path to the NAR'"`
-	Path string `kong:"arg,type='string',help='Path inside the NAR, without leading slash'"`
+	Path string `kong:"arg,type='string',help='Path inside the NAR, starting with \"/\".'"`
 }
 
 func (cmd *CatCmd) Run() error {

--- a/cmd/gonix/nar/ls.go
+++ b/cmd/gonix/nar/ls.go
@@ -11,7 +11,7 @@ import (
 
 type LsCmd struct {
 	Nar       string `kong:"arg,type:'existingfile',help='Path to the NAR'"`
-	Path      string `kong:"arg,optional,type='string',default='',help='Path inside the NAR, without leading slash'"`
+	Path      string `kong:"arg,optional,type='string',default='/',help='Path inside the NAR. Defaults to \"/\".'"`
 	Recursive bool   `kong:"short='R',help='Whether to list recursively, or only the current level.'"`
 }
 
@@ -22,13 +22,7 @@ func headerLineString(hdr *nar.Header) string {
 
 	sb.WriteString(hdr.FileInfo().Mode().String())
 	sb.WriteString(" ")
-
-	// write name. In case of an empty path, write a "."
-	if hdr.Path == "" {
-		sb.WriteString(".")
-	} else {
-		sb.WriteString(hdr.Path)
-	}
+	sb.WriteString(hdr.Path)
 
 	// if regular file, show size in parantheses. We don't bother about aligning it nicely,
 	// as that'd require reading in all headers first before printing them out.

--- a/pkg/nar/dump.go
+++ b/pkg/nar/dump.go
@@ -20,7 +20,7 @@ func DumpPath(w io.Writer, path string) error {
 	// make sure the NAR writer is always closed, so the underlying goroutine is stopped
 	defer nw.Close()
 
-	err = dumpPath(nw, path, "")
+	err = dumpPath(nw, path, "/")
 	if err != nil {
 		return err
 	}

--- a/pkg/nar/dump_test.go
+++ b/pkg/nar/dump_test.go
@@ -111,7 +111,7 @@ func TestDumpPathRecursion(t *testing.T) {
 		hdr, err := nr.Next()
 		assert.NoError(t, err)
 		assert.Equal(t, &nar.Header{
-			Path: "",
+			Path: "/",
 			Type: nar.TypeDirectory,
 		}, hdr)
 
@@ -119,7 +119,7 @@ func TestDumpPathRecursion(t *testing.T) {
 		hdr, err = nr.Next()
 		assert.NoError(t, err)
 		assert.Equal(t, &nar.Header{
-			Path: "a",
+			Path: "/a",
 			Type: nar.TypeRegular,
 			Size: 1,
 		}, hdr)

--- a/pkg/nar/header.go
+++ b/pkg/nar/header.go
@@ -22,15 +22,13 @@ type Header struct {
 // checking for valid paths and inconsistent fields, and returns an error if it
 // fails validation.
 func (h *Header) Validate() error {
-	// Path may not start with a /, and may not contain null bytes
-	if len(h.Path) > 1 {
-		if h.Path[:1] == "/" {
-			return fmt.Errorf("path %v starts with a /", h.Path)
-		}
+	// Path needs to start with a /, and must not contain null bytes
+	if len(h.Path) < 1 || h.Path[0:1] != "/" {
+		return fmt.Errorf("path must start with a /")
+	}
 
-		if strings.ContainsAny(h.Path, "\u0000") {
-			return fmt.Errorf("path contains null bytes")
-		}
+	if strings.ContainsAny(h.Path, "\u0000") {
+		return fmt.Errorf("path may not contain null bytes")
 	}
 
 	// Regular files and directories may not have LinkTarget set.

--- a/pkg/nar/header_test.go
+++ b/pkg/nar/header_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestHeaderValidate(t *testing.T) {
 	headerRegular := &nar.Header{
-		Path:       "foo/bar",
+		Path:       "/foo/bar",
 		Type:       nar.TypeRegular,
 		LinkTarget: "",
 		Size:       0,
@@ -23,10 +23,10 @@ func TestHeaderValidate(t *testing.T) {
 
 	t.Run("invalid path", func(t *testing.T) {
 		invHeader := *headerRegular
-		invHeader.Path = "/foo/bar"
+		invHeader.Path = "foo/bar"
 		assert.Error(t, invHeader.Validate())
 
-		invHeader.Path = "foo/bar\000/"
+		invHeader.Path = "/foo/bar\000/"
 		assert.Error(t, invHeader.Validate())
 	})
 

--- a/pkg/nar/reader.go
+++ b/pkg/nar/reader.go
@@ -75,7 +75,7 @@ func NewReader(r io.Reader) (*Reader, error) {
 			return
 		}
 
-		err := narReader.parseNode("")
+		err := narReader.parseNode("/")
 		if err != nil {
 			narReader.errors <- err
 		} else {

--- a/pkg/nar/reader_test.go
+++ b/pkg/nar/reader_test.go
@@ -35,7 +35,7 @@ func TestReaderEmptyDirectory(t *testing.T) {
 	hdr, err := nr.Next()
 	assert.NoError(t, err)
 	assert.Equal(t, &nar.Header{
-		Path: "",
+		Path: "/",
 		Type: nar.TypeDirectory,
 	}, hdr)
 
@@ -56,7 +56,7 @@ func TestReaderOneByteRegular(t *testing.T) {
 	hdr, err := nr.Next()
 	assert.NoError(t, err)
 	assert.Equal(t, &nar.Header{
-		Path:       "",
+		Path:       "/",
 		Type:       nar.TypeRegular,
 		Size:       1,
 		Executable: false,
@@ -84,7 +84,7 @@ func TestReaderSymlink(t *testing.T) {
 	hdr, err := nr.Next()
 	assert.NoError(t, err)
 	assert.Equal(t, &nar.Header{
-		Path:       "",
+		Path:       "/",
 		Type:       nar.TypeSymlink,
 		LinkTarget: "/nix/store/somewhereelse",
 		Size:       0,
@@ -122,175 +122,175 @@ func TestReaderSmoketest(t *testing.T) {
 	assert.Equal(t, io.EOF, err)
 
 	headers := []nar.Header{
-		{Type: nar.TypeDirectory},
-		{Type: nar.TypeDirectory, Path: "bin"},
+		{Type: nar.TypeDirectory, Path: "/"},
+		{Type: nar.TypeDirectory, Path: "/bin"},
 		{
 			Type:       nar.TypeRegular,
-			Path:       "bin/arp",
+			Path:       "/bin/arp",
 			Executable: true,
 			Size:       55288,
 		},
 		{
 			Type:       nar.TypeSymlink,
-			Path:       "bin/dnsdomainname",
+			Path:       "/bin/dnsdomainname",
 			LinkTarget: "hostname",
 		},
 		{
 			Type:       nar.TypeSymlink,
-			Path:       "bin/domainname",
+			Path:       "/bin/domainname",
 			LinkTarget: "hostname",
 		},
 		{
 			Type:       nar.TypeRegular,
-			Path:       "bin/hostname",
+			Path:       "/bin/hostname",
 			Executable: true,
 			Size:       17704,
 		},
 		{
 			Type:       nar.TypeRegular,
-			Path:       "bin/ifconfig",
+			Path:       "/bin/ifconfig",
 			Executable: true,
 			Size:       72576,
 		},
 		{
 			Type:       nar.TypeRegular,
-			Path:       "bin/nameif",
+			Path:       "/bin/nameif",
 			Executable: true,
 			Size:       18776,
 		},
 		{
 			Type:       nar.TypeRegular,
-			Path:       "bin/netstat",
+			Path:       "/bin/netstat",
 			Executable: true,
 			Size:       131784,
 		},
 		{
 			Type:       nar.TypeSymlink,
-			Path:       "bin/nisdomainname",
+			Path:       "/bin/nisdomainname",
 			LinkTarget: "hostname",
 		},
 		{
 			Type:       nar.TypeRegular,
-			Path:       "bin/plipconfig",
+			Path:       "/bin/plipconfig",
 			Executable: true,
 			Size:       13160,
 		},
 		{
 			Type:       nar.TypeRegular,
-			Path:       "bin/rarp",
+			Path:       "/bin/rarp",
 			Executable: true,
 			Size:       30384,
 		},
 		{
 			Type:       nar.TypeRegular,
-			Path:       "bin/route",
+			Path:       "/bin/route",
 			Executable: true,
 			Size:       61928,
 		},
 		{
 			Type:       nar.TypeRegular,
-			Path:       "bin/slattach",
+			Path:       "/bin/slattach",
 			Executable: true,
 			Size:       35672,
 		},
 		{
 			Type:       nar.TypeSymlink,
-			Path:       "bin/ypdomainname",
+			Path:       "/bin/ypdomainname",
 			LinkTarget: "hostname",
 		},
 		{
 			Type:       nar.TypeSymlink,
-			Path:       "sbin",
+			Path:       "/sbin",
 			LinkTarget: "bin",
 		},
 		{
 			Type: nar.TypeDirectory,
-			Path: "share",
+			Path: "/share",
 		},
 		{
 			Type: nar.TypeDirectory,
-			Path: "share/man",
+			Path: "/share/man",
 		},
 		{
 			Type: nar.TypeDirectory,
-			Path: "share/man/man1",
+			Path: "/share/man/man1",
 		},
 		{
 			Type: nar.TypeRegular,
-			Path: "share/man/man1/dnsdomainname.1.gz",
+			Path: "/share/man/man1/dnsdomainname.1.gz",
 			Size: 40,
 		},
 		{
 			Type: nar.TypeRegular,
-			Path: "share/man/man1/domainname.1.gz",
+			Path: "/share/man/man1/domainname.1.gz",
 			Size: 40,
 		},
 		{
 			Type: nar.TypeRegular,
-			Path: "share/man/man1/hostname.1.gz",
+			Path: "/share/man/man1/hostname.1.gz",
 			Size: 1660,
 		},
 		{
 			Type: nar.TypeRegular,
-			Path: "share/man/man1/nisdomainname.1.gz",
+			Path: "/share/man/man1/nisdomainname.1.gz",
 			Size: 40,
 		},
 		{
 			Type: nar.TypeRegular,
-			Path: "share/man/man1/ypdomainname.1.gz",
+			Path: "/share/man/man1/ypdomainname.1.gz",
 			Size: 40,
 		},
 		{
 			Type: nar.TypeDirectory,
-			Path: "share/man/man5",
+			Path: "/share/man/man5",
 		},
 		{
 			Type: nar.TypeRegular,
-			Path: "share/man/man5/ethers.5.gz",
+			Path: "/share/man/man5/ethers.5.gz",
 			Size: 563,
 		},
 		{
 			Type: nar.TypeDirectory,
-			Path: "share/man/man8",
+			Path: "/share/man/man8",
 		},
 		{
 			Type: nar.TypeRegular,
-			Path: "share/man/man8/arp.8.gz",
+			Path: "/share/man/man8/arp.8.gz",
 			Size: 2464,
 		},
 		{
 			Type: nar.TypeRegular,
-			Path: "share/man/man8/ifconfig.8.gz",
+			Path: "/share/man/man8/ifconfig.8.gz",
 			Size: 3382,
 		},
 		{
 			Type: nar.TypeRegular,
-			Path: "share/man/man8/nameif.8.gz",
+			Path: "/share/man/man8/nameif.8.gz",
 			Size: 523,
 		},
 		{
 			Type: nar.TypeRegular,
-			Path: "share/man/man8/netstat.8.gz",
+			Path: "/share/man/man8/netstat.8.gz",
 			Size: 4284,
 		},
 		{
 			Type: nar.TypeRegular,
-			Path: "share/man/man8/plipconfig.8.gz",
+			Path: "/share/man/man8/plipconfig.8.gz",
 			Size: 889,
 		},
 		{
 			Type: nar.TypeRegular,
-			Path: "share/man/man8/rarp.8.gz",
+			Path: "/share/man/man8/rarp.8.gz",
 			Size: 1198,
 		},
 		{
 			Type: nar.TypeRegular,
-			Path: "share/man/man8/route.8.gz",
+			Path: "/share/man/man8/route.8.gz",
 			Size: 3525,
 		},
 		{
 			Type: nar.TypeRegular,
-			Path: "share/man/man8/slattach.8.gz",
+			Path: "/share/man/man8/slattach.8.gz",
 			Size: 1441,
 		},
 	}
@@ -302,7 +302,7 @@ func TestReaderSmoketest(t *testing.T) {
 		}
 
 		// read one of the files
-		if hdr.Path == "bin/arp" {
+		if hdr.Path == "/bin/arp" {
 			f, err := os.Open("../../test/testdata/nar_1094wph9z4nwlgvsd53abfz8i117ykiv5dwnq9nnhz846s7xqd7d.nar_bin_arp")
 			assert.NoError(t, err)
 
@@ -320,7 +320,7 @@ func TestReaderSmoketest(t *testing.T) {
 		// ensure reading from symlinks or directories doesn't return any actual contents
 		// we pick examples that previously returned a regular file, so there might
 		// previously have been a reader pointing to something.
-		if hdr.Path == "bin/dnsdomainname" || hdr.Path == "share/man/man5" {
+		if hdr.Path == "/bin/dnsdomainname" || hdr.Path == "/share/man/man5" {
 			actualContents, err := ioutil.ReadAll(nr)
 			if assert.NoError(t, err) {
 				assert.Equal(t, []byte{}, actualContents)

--- a/pkg/nar/writer.go
+++ b/pkg/nar/writer.go
@@ -61,9 +61,9 @@ func NewWriter(w io.Writer) (*Writer, error) {
 			return
 		}
 
-		// ensure the first item received always has an empty path.
-		if header.Path != "" {
-			narWriter.errors <- fmt.Errorf("first header always needs to have an empty path")
+		// ensure the first item received always has a "/" as path.
+		if header.Path != "/" {
+			narWriter.errors <- fmt.Errorf("first header always needs to have a / as path")
 			close(narWriter.errors)
 
 			return

--- a/pkg/nar/writer_test.go
+++ b/pkg/nar/writer_test.go
@@ -29,7 +29,7 @@ func TestWriterEmptyDirectory(t *testing.T) {
 	assert.NoError(t, err)
 
 	hdr := &nar.Header{
-		Path: "",
+		Path: "/",
 		Type: nar.TypeDirectory,
 	}
 
@@ -53,7 +53,7 @@ func TestWriterOneByteRegular(t *testing.T) {
 	assert.NoError(t, err)
 
 	hdr := nar.Header{
-		Path:       "",
+		Path:       "/",
 		Type:       nar.TypeRegular,
 		Size:       1,
 		Executable: false,
@@ -79,7 +79,7 @@ func TestWriterSymlink(t *testing.T) {
 	assert.NoError(t, err)
 
 	hdr := nar.Header{
-		Path:       "",
+		Path:       "/",
 		Type:       nar.TypeSymlink,
 		LinkTarget: "/nix/store/somewhereelse",
 		Size:       0,
@@ -167,14 +167,14 @@ func TestWriterErrorsTransitions(t *testing.T) {
 
 		// write a directory node
 		err = nw.WriteHeader(&nar.Header{
-			Path: "",
+			Path: "/",
 			Type: nar.TypeDirectory,
 		})
 		assert.NoError(t, err)
 
 		// write a symlink "a/foo", but missing the directory node "a" in between should error
 		err = nw.WriteHeader(&nar.Header{
-			Path:       "a/foo",
+			Path:       "/a/foo",
 			Type:       nar.TypeSymlink,
 			LinkTarget: "doesntmatter",
 		})
@@ -186,9 +186,9 @@ func TestWriterErrorsTransitions(t *testing.T) {
 		nw, err := nar.NewWriter(&buf)
 		assert.NoError(t, err)
 
-		// write a directory node for "a" without writing the one for ""
+		// write a directory node for "/a" without writing the one for "/"
 		err = nw.WriteHeader(&nar.Header{
-			Path: "a",
+			Path: "/a",
 			Type: nar.TypeDirectory,
 		})
 		assert.Error(t, err)
@@ -201,7 +201,7 @@ func TestWriterErrorsTransitions(t *testing.T) {
 
 		// write a symlink for "a" without writing the directory one for ""
 		err = nw.WriteHeader(&nar.Header{
-			Path:       "a",
+			Path:       "/a",
 			Type:       nar.TypeSymlink,
 			LinkTarget: "foo",
 		})
@@ -215,22 +215,22 @@ func TestWriterErrorsTransitions(t *testing.T) {
 
 		// write a directory node
 		err = nw.WriteHeader(&nar.Header{
-			Path: "",
+			Path: "/",
 			Type: nar.TypeDirectory,
 		})
 		assert.NoError(t, err)
 
-		// write a symlink node for "a"
+		// write a symlink node for "/a"
 		err = nw.WriteHeader(&nar.Header{
-			Path:       "a",
+			Path:       "/a",
 			Type:       nar.TypeSymlink,
 			LinkTarget: "doesntmatter",
 		})
 		assert.NoError(t, err)
 
-		// write a symlink "a/b", which should fail, as a was a symlink, not directory
+		// write a symlink "/a/b", which should fail, as a was a symlink, not directory
 		err = nw.WriteHeader(&nar.Header{
-			Path:       "a/b",
+			Path:       "/a/b",
 			Type:       nar.TypeSymlink,
 			LinkTarget: "doesntmatter",
 		})
@@ -244,22 +244,22 @@ func TestWriterErrorsTransitions(t *testing.T) {
 
 		// write a directory node
 		err = nw.WriteHeader(&nar.Header{
-			Path: "",
+			Path: "/",
 			Type: nar.TypeDirectory,
 		})
 		assert.NoError(t, err)
 
-		// write a symlink for "b"
+		// write a symlink for "/b"
 		err = nw.WriteHeader(&nar.Header{
-			Path:       "b",
+			Path:       "/b",
 			Type:       nar.TypeSymlink,
 			LinkTarget: "foo",
 		})
 		assert.NoError(t, err)
 
-		// write a symlink for "a"
+		// write a symlink for "/a"
 		err = nw.WriteHeader(&nar.Header{
-			Path:       "a",
+			Path:       "/a",
 			Type:       nar.TypeSymlink,
 			LinkTarget: "foo",
 		})
@@ -273,22 +273,22 @@ func TestWriterErrorsTransitions(t *testing.T) {
 
 		// write a directory node
 		err = nw.WriteHeader(&nar.Header{
-			Path: "",
+			Path: "/",
 			Type: nar.TypeDirectory,
 		})
 		assert.NoError(t, err)
 
-		// write a symlink for "a"
+		// write a symlink for "/a"
 		err = nw.WriteHeader(&nar.Header{
-			Path:       "a",
+			Path:       "/a",
 			Type:       nar.TypeSymlink,
 			LinkTarget: "foo",
 		})
 		assert.NoError(t, err)
 
-		// write a symlink for "a"
+		// write a symlink for "/a"
 		err = nw.WriteHeader(&nar.Header{
-			Path:       "a",
+			Path:       "/a",
 			Type:       nar.TypeSymlink,
 			LinkTarget: "foo",
 		})


### PR DESCRIPTION
This has confused at least two people.

This will bring the `gonix` CLI a bit more in line with how Nix behaves, gets rid of the ugly `.` when printing the root of a NAR.

cc @manveru 