### PR TITLE
pkg/derivation: Implement String method

### DIFF
--- a/pkg/derivation/derivation.go
+++ b/pkg/derivation/derivation.go
@@ -62,6 +62,11 @@ func (d *Derivation) WriteDerivation(writer io.Writer) error {
 	return err
 }
 
+// String returns the default (first) output path.
+func (d *Derivation) String() string {
+	return d.Outputs[0].Path
+}
+
 type Output struct {
 	Content       string `json:"name" parser:"'(' @String ','"`
 	Path          string `json:"path" parser:"@NixPath ','"`

--- a/pkg/derivation/derivation_test.go
+++ b/pkg/derivation/derivation_test.go
@@ -152,3 +152,22 @@ func TestEncoder(t *testing.T) {
 		}
 	})
 }
+
+func TestOutputs(t *testing.T) {
+	drv := &derivation.Derivation{
+		Outputs: []derivation.Output{
+			{
+				Content: "foo",
+				Path:    "dummy",
+			},
+			{
+				Content: "bar",
+				Path:    "dummy2",
+			},
+		},
+	}
+
+	t.Run("String", func(t *testing.T) {
+		assert.Equal(t, "dummy", drv.String())
+	})
+}


### PR DESCRIPTION
That outputs the default output path, much like Nix string interpolation does.

Suggested by @jfroche in https://github.com/nix-community/go-nix/pull/38#issuecomment-1114051028.