### PR TITLE
pkg/nar/writer: Compare order of NAR members correctly

### DIFF
--- a/pkg/nar/reader.go
+++ b/pkg/nar/reader.go
@@ -322,7 +322,7 @@ func (nr *Reader) Next() (*Header, error) {
 	// return either an error or headers
 	select {
 	case hdr := <-nr.headers:
-		if hdr.Path <= nr.previousHdrPath {
+		if !PathIsLexicographicallyOrdered(nr.previousHdrPath, hdr.Path) {
 			err := fmt.Errorf("received header in the wrong order, %v <= %v", hdr.Path, nr.previousHdrPath)
 
 			// blow fuse

--- a/pkg/nar/util.go
+++ b/pkg/nar/util.go
@@ -7,3 +7,28 @@ import "strings"
 func IsValidNodeName(nodeName string) bool {
 	return !strings.Contains(nodeName, "/") && !strings.ContainsAny(nodeName, "\u0000")
 }
+
+// PathIsLexicographicallyOrdered checks if two paths are lexicographically ordered component by component.
+func PathIsLexicographicallyOrdered(path1 string, path2 string) bool {
+	if path1 > path2 {
+		path1Segments := strings.Split(path1, "/")
+		path2Segments := strings.Split(path2, "/")
+
+		// n is the lower number of segments of the two paths.
+		var n int
+		if len(path1Segments) < len(path2Segments) {
+			n = len(path1Segments)
+		} else {
+			n = len(path2Segments)
+		}
+
+		// check all segments individually
+		for i := 0; i < n; i++ {
+			if !(path1Segments[i] <= path2Segments[i]) {
+				return false
+			}
+		}
+	}
+
+	return true
+}

--- a/pkg/nar/util_test.go
+++ b/pkg/nar/util_test.go
@@ -1,0 +1,50 @@
+package nar_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/nix-community/go-nix/pkg/nar"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLexicographicallyOrdered(t *testing.T) {
+	testCases := []struct {
+		path1    string
+		path2    string
+		expected bool
+	}{
+		{
+			path1:    "/foo",
+			path2:    "/foo",
+			expected: true,
+		},
+		{
+			path1:    "/fooa",
+			path2:    "/foob",
+			expected: true,
+		},
+		{
+			path1:    "/foob",
+			path2:    "/fooa",
+			expected: false,
+		},
+		{
+			path1:    "/cmd/structlayout/main.go",
+			path2:    "/cmd/structlayout-optimize",
+			expected: true,
+		},
+		{
+			path1:    "/cmd/structlayout-optimize",
+			path2:    "/cmd/structlayout-ao/main.go",
+			expected: false,
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			result := nar.PathIsLexicographicallyOrdered(testCase.path1, testCase.path2)
+			assert.Equal(t, result, testCase.expected)
+		})
+	}
+}

--- a/pkg/nar/writer.go
+++ b/pkg/nar/writer.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"strings"
 
 	"github.com/nix-community/go-nix/pkg/wire"
 )
@@ -203,31 +202,12 @@ func (nw *Writer) emitNode(currentHeader *Header) (*Header, error) {
 
 		// compare Path of the received header.
 		// It needs to be lexicographically greater the previous one.
-		if currentHeader.Path > nextHeader.Path { // Happy path, quick compare
-			// For subdirectory structures with a common prefix we need to check not just
-			// the simple string but each parent path one by one.
-			// Example layout:
-			// /cmd/structlayout/main.go
-			// /cmd/structlayout-optimize
-			currentHeaderPaths := strings.Split(currentHeader.Path, "/")
-			nextHeaderPaths := strings.Split(nextHeader.Path, "/")
-
-			var n int
-			if len(currentHeaderPaths) < len(nextHeaderPaths) {
-				n = len(currentHeaderPaths)
-			} else {
-				n = len(nextHeaderPaths)
-			}
-
-			for i := 0; i < n; i++ {
-				if !(currentHeaderPaths[i] <= nextHeaderPaths[i]) {
-					return nil, fmt.Errorf(
-						"received %v, which isn't lexicographically greater than the previous one %v",
-						nextHeader.Path,
-						currentHeader.Path,
-					)
-				}
-			}
+		if !PathIsLexicographicallyOrdered(currentHeader.Path, nextHeader.Path) {
+			return nil, fmt.Errorf(
+				"received %v, which isn't lexicographically greater than the previous one %v",
+				nextHeader.Path,
+				currentHeader.Path,
+			)
 		}
 
 		// calculate the relative path between the previous and now-read header,

--- a/pkg/nar/writer_test.go
+++ b/pkg/nar/writer_test.go
@@ -294,4 +294,40 @@ func TestWriterErrorsTransitions(t *testing.T) {
 		})
 		assert.Error(t, err)
 	})
+
+	t.Run("lexicographically sorted with nested directory and common prefix", func(t *testing.T) {
+		var buf bytes.Buffer
+		nw, err := nar.NewWriter(&buf)
+		assert.NoError(t, err)
+
+		// write a directory node
+		err = nw.WriteHeader(&nar.Header{
+			Path: "/",
+			Type: nar.TypeDirectory,
+		})
+		assert.NoError(t, err)
+
+		// write a directory node with name "/foo"
+		err = nw.WriteHeader(&nar.Header{
+			Path: "/foo",
+			Type: nar.TypeDirectory,
+		})
+		assert.NoError(t, err)
+
+		// write a symlink for "/foo/b"
+		err = nw.WriteHeader(&nar.Header{
+			Path:       "/foo/b",
+			Type:       nar.TypeSymlink,
+			LinkTarget: "foo",
+		})
+		assert.NoError(t, err)
+
+		// write a symlink for "/foo-a"
+		err = nw.WriteHeader(&nar.Header{
+			Path:       "/foo-a",
+			Type:       nar.TypeSymlink,
+			LinkTarget: "foo",
+		})
+		assert.NoError(t, err)
+	})
 }


### PR DESCRIPTION
The current implementation breaks when the string representation for
the _full path_ is not lexicographically ordered.

This breaks when two nested directories share a prefix such as:
- /cmd/structlayout/main.go
- /cmd/structlayout-optimize

The full path for these strings is not in correct lexicographical
order, but each component is.