### PR TITLE
pkg/nar: Add DumpPathFilter

### DIFF
--- a/pkg/nar/dump_test.go
+++ b/pkg/nar/dump_test.go
@@ -87,6 +87,24 @@ func TestDumpPathSymlink(t *testing.T) {
 	}
 }
 
+// TestDumpPathUnknown makes sure calling DumpPath on a path with a fifo
+// doesn't panic, but returns an error.
+func TestDumpPathUnknown(t *testing.T) {
+	tmpDir := t.TempDir()
+	p := filepath.Join(tmpDir, "a")
+
+	err := syscall.Mkfifo(p, 0o644)
+	if err != nil {
+		panic(err)
+	}
+
+	var buf bytes.Buffer
+
+	err = nar.DumpPath(&buf, p)
+	assert.Error(t, err)
+	assert.Containsf(t, err.Error(), "invalid mode", "error should complain about invalid mode")
+}
+
 func TestDumpPathRecursion(t *testing.T) {
 	tmpDir := t.TempDir()
 	p := filepath.Join(tmpDir, "a")

--- a/pkg/nar/header.go
+++ b/pkg/nar/header.go
@@ -31,6 +31,11 @@ func (h *Header) Validate() error {
 		return fmt.Errorf("path may not contain null bytes")
 	}
 
+	// Constructing a NAR with TypeUnknown is invalid
+	if h.Type == TypeUnknown {
+		return fmt.Errorf("type is unknown")
+	}
+
 	// Regular files and directories may not have LinkTarget set.
 	if h.Type == TypeRegular || h.Type == TypeDirectory {
 		if h.LinkTarget != "" {
@@ -92,6 +97,10 @@ func (fi headerFileInfo) Mode() fs.FileMode {
 		mode |= (syscall.S_IXUSR | syscall.S_IXGRP | syscall.S_IXOTH)
 	case TypeSymlink:
 		mode = fs.ModePerm | fs.ModeSymlink
+	case TypeUnknown:
+		// It's not possible to create a NAR with a member of TypeUnknown using either
+		// the reader or the writer, only by manually populating structs.
+		panic("No mode for TypeUnknown")
 	}
 
 	return mode

--- a/pkg/nar/types.go
+++ b/pkg/nar/types.go
@@ -12,6 +12,8 @@ const (
 	TypeDirectory = NodeType("directory")
 	// TypeSymlink represents a file symlink.
 	TypeSymlink = NodeType("symlink")
+	// TypeUnknown represents an unknown file (such as device nodes or fifos).
+	TypeUnknown = NodeType("unknown")
 )
 
 func (t NodeType) String() string {


### PR DESCRIPTION
This function adds source filtering capabilities to DumpPath.
The interface of this mimics the behaviour of the Nix builtin filterSource.