### PR TITLE
pkg/derivation: rename Output.Content to Output.Name

### DIFF
--- a/pkg/derivation/derivation.go
+++ b/pkg/derivation/derivation.go
@@ -28,11 +28,11 @@ func (d *Derivation) Validate() error {
 	for i, o := range d.Outputs {
 		err := o.Validate()
 		if err != nil {
-			return fmt.Errorf("error validating output '%s': %w", o.Content, err)
+			return fmt.Errorf("error validating output '%s': %w", o.Name, err)
 		}
 
-		if i > 0 && o.Content < d.Outputs[i-1].Content {
-			return fmt.Errorf("invalid output order: %s < %s", o.Content, d.Outputs[i-1].Content)
+		if i > 0 && o.Name < d.Outputs[i-1].Name {
+			return fmt.Errorf("invalid output order: %s < %s", o.Name, d.Outputs[i-1].Name)
 		}
 	}
 	// FUTUREWORK: check output store path hashes and derivation hashes for consistency (#41)
@@ -85,7 +85,7 @@ func (d *Derivation) Validate() error {
 func (d *Derivation) WriteDerivation(writer io.Writer) error {
 	outputs := make([][]byte, len(d.Outputs))
 	for i, o := range d.Outputs {
-		outputs[i] = encodeArray('(', ')', true, []byte(o.Content), []byte(o.Path), []byte(o.HashAlgorithm), []byte(o.Hash))
+		outputs[i] = encodeArray('(', ')', true, []byte(o.Name), []byte(o.Path), []byte(o.HashAlgorithm), []byte(o.Hash))
 	}
 
 	inputDerivations := make([][]byte, len(d.InputDerivations))
@@ -129,15 +129,15 @@ func (d *Derivation) String() string {
 }
 
 type Output struct {
-	Content       string `json:"name" parser:"'(' @String ','"`
+	Name          string `json:"name" parser:"'(' @String ','"`
 	Path          string `json:"path" parser:"@NixPath ','"`
 	HashAlgorithm string `json:"hashAlgo" parser:"@String ','"`
 	Hash          string `json:"hash" parser:"@String ')'"`
 }
 
 func (o *Output) Validate() error {
-	if o.Content == "" {
-		return fmt.Errorf("empty content (output name)")
+	if o.Name == "" {
+		return fmt.Errorf("empty output name")
 	}
 
 	_, err := nixpath.FromString(o.Path)

--- a/pkg/derivation/derivation_test.go
+++ b/pkg/derivation/derivation_test.go
@@ -25,7 +25,7 @@ func TestParser(t *testing.T) {
 			"m5j1yp47lw1psd9n6bzina1167abbprr-bash44-023.drv",
 			//			"basic.drv",
 			&derivation.Output{
-				Content:       "out",
+				Name:          "out",
 				Path:          "/nix/store/x9cyj78gzd1wjf0xsiad1pa3ricbj566-bash44-023",
 				HashAlgorithm: "sha256",
 				Hash:          "4fec236f3fbd3d0c47b893fdfa9122142a474f6ef66c20ffb6c0f4864dd591b6",
@@ -157,12 +157,12 @@ func TestOutputs(t *testing.T) {
 	drv := &derivation.Derivation{
 		Outputs: []derivation.Output{
 			{
-				Content: "foo",
-				Path:    "dummy",
+				Name: "foo",
+				Path: "dummy",
 			},
 			{
-				Content: "bar",
-				Path:    "dummy2",
+				Name: "bar",
+				Path: "dummy2",
 			},
 		},
 	}
@@ -188,7 +188,7 @@ func TestValidate(t *testing.T) {
 	}
 
 	t.Run("InvalidOutput", func(t *testing.T) {
-		t.Run("EmptyOutputs", func(t *testing.T) {
+		t.Run("NoOutputsAtAll", func(t *testing.T) {
 			drv := getDerivation()
 
 			drv.Outputs = []derivation.Output{}
@@ -204,10 +204,10 @@ func TestValidate(t *testing.T) {
 			)
 		})
 
-		t.Run("NoContent", func(t *testing.T) {
+		t.Run("NoOutputName", func(t *testing.T) {
 			drv := getDerivation()
 
-			drv.Outputs[0].Content = ""
+			drv.Outputs[0].Name = ""
 
 			err := drv.Validate()
 			assert.Error(t, err)
@@ -215,7 +215,7 @@ func TestValidate(t *testing.T) {
 			assert.Containsf(
 				t,
 				err.Error(),
-				"empty content",
+				"empty output name",
 				"error should complain about missing output name",
 			)
 		})
@@ -239,7 +239,7 @@ func TestValidate(t *testing.T) {
 		t.Run("InvalidOrder", func(t *testing.T) {
 			drv := getDerivation()
 
-			drv.Outputs[0].Content = "foo"
+			drv.Outputs[0].Name = "foo"
 
 			err := drv.Validate()
 			assert.Error(t, err)


### PR DESCRIPTION
This is the name of the output. It might be the contents of some
structure, but actually calling this struct attribute `Name` makes much
more sense.