### PR TITLE
pkg/nar: Reduce the number of allocations when writing derivations

### DIFF
--- a/pkg/derivation/derivation.go
+++ b/pkg/derivation/derivation.go
@@ -91,7 +91,7 @@ func (d *Derivation) WriteDerivation(writer io.Writer) error {
 	inputDerivations := make([][]byte, len(d.InputDerivations))
 	{
 		for i, in := range d.InputDerivations {
-			names := encodeArray('[', ']', true, stringsToBytes(in.Name)...)
+			names := encodeArrayStrings('[', ']', true, in.Name...)
 			inputDerivations[i] = encodeArray('(', ')', false, quoteString(in.Path), names)
 		}
 	}
@@ -112,10 +112,10 @@ func (d *Derivation) WriteDerivation(writer io.Writer) error {
 		encodeArray('(', ')', false,
 			encodeArray('[', ']', false, outputs...),
 			encodeArray('[', ']', false, inputDerivations...),
-			encodeArray('[', ']', true, stringsToBytes(d.InputSources)...),
+			encodeArrayStrings('[', ']', true, d.InputSources...),
 			escapeString(d.Platform),
 			escapeString(d.Builder),
-			encodeArray('[', ']', true, stringsToBytes(d.Arguments)...),
+			encodeArrayStrings('[', ']', true, d.Arguments...),
 			encodeArray('[', ']', false, envVars...),
 		),
 	)


### PR DESCRIPTION
Using the following test program:
``` go
package main

import (
	"fmt"
	"github.com/nix-community/go-nix/pkg/derivation"
	"os"
	"testing"
)

type nullWriter struct{}

func (n *nullWriter) Write(b []byte) (int, error) {
	return len(b), nil
}

func main() {

	derivationFile, err := os.Open("./test/testdata/cl5fr6hlr6hdqza2vgb9qqy5s26wls8i-jq-1.6.drv")
	if err != nil {
		panic(err)
	}

	drv, err := derivation.ReadDerivation(derivationFile)
	if err != nil {
		panic(err)
	}

	writer := &nullWriter{}

	fmt.Println("Allocs:", int(testing.AllocsPerRun(10, func() {
		err = drv.WriteDerivation(writer)
		if err != nil {
			panic(err)
		}
	})))

}
```

- Before
Allocs: 180

- After
Allocs: 123

The added duplication could be removed if we used Go 1.18 and generics.