### PR TITLE
pkg/derivation: align Derivation struct with json format

### DIFF
--- a/pkg/derivation/derivation.go
+++ b/pkg/derivation/derivation.go
@@ -108,12 +108,6 @@ func (d *Derivation) Validate() error {
 	return nil
 }
 
-// String returns the path of the derivation.
-func (d *Derivation) String() string {
-	// TODO: replace with drv path
-	return "TODO"
-}
-
 type Output struct {
 	Path          string `json:"path"`
 	HashAlgorithm string `json:"hashAlgo"`

--- a/pkg/derivation/derivation.go
+++ b/pkg/derivation/derivation.go
@@ -88,10 +88,21 @@ func (d *Derivation) Validate() error {
 		return fmt.Errorf("required attribute 'builder' missing")
 	}
 
+	// there has to be an env variable with key `name`.
+	hasNameEnv := false
+
 	for k := range d.Env {
 		if k == "" {
 			return fmt.Errorf("empty environment variable key")
 		}
+
+		if k == "name" {
+			hasNameEnv = true
+		}
+	}
+
+	if !hasNameEnv {
+		return fmt.Errorf("env 'name' not found")
 	}
 
 	return nil

--- a/pkg/derivation/derivation.go
+++ b/pkg/derivation/derivation.go
@@ -78,48 +78,6 @@ func (d *Derivation) Validate() error {
 	return nil
 }
 
-// WriteDerivation writes the textual representation of the derivation to the passed writer.
-func (d *Derivation) WriteDerivation(writer io.Writer) error {
-	outputs := make([][]byte, len(d.Outputs))
-	for i, o := range d.Outputs {
-		outputs[i] = encodeArray('(', ')', true, []byte(o.Name), []byte(o.Path), []byte(o.HashAlgorithm), []byte(o.Hash))
-	}
-
-	inputDerivations := make([][]byte, len(d.InputDerivations))
-	{
-		for i, in := range d.InputDerivations {
-			names := encodeArray('[', ']', true, stringsToBytes(in.Name)...)
-			inputDerivations[i] = encodeArray('(', ')', false, quoteString(in.Path), names)
-		}
-	}
-
-	envVars := make([][]byte, len(d.EnvVars))
-	{
-		for i, e := range d.EnvVars {
-			envVars[i] = encodeArray('(', ')', false, quoteString(e.Key), quoteString(e.Value))
-		}
-	}
-
-	_, err := writer.Write([]byte("Derive"))
-	if err != nil {
-		return err
-	}
-
-	_, err = writer.Write(
-		encodeArray('(', ')', false,
-			encodeArray('[', ']', false, outputs...),
-			encodeArray('[', ']', false, inputDerivations...),
-			encodeArray('[', ']', true, stringsToBytes(d.InputSources)...),
-			quoteString(d.Platform),
-			quoteString(d.Builder),
-			encodeArray('[', ']', true, stringsToBytes(d.Arguments)...),
-			encodeArray('[', ']', false, envVars...),
-		),
-	)
-
-	return err
-}
-
 // String returns the default (first) output path.
 func (d *Derivation) String() string {
 	return d.Outputs[0].Path

--- a/pkg/derivation/derivation.go
+++ b/pkg/derivation/derivation.go
@@ -2,7 +2,6 @@ package derivation
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/nix-community/go-nix/pkg/nixpath"
 )
@@ -125,18 +124,4 @@ func (env *Env) Validate() error {
 	}
 
 	return nil
-}
-
-func ReadDerivation(reader io.Reader) (*Derivation, error) {
-	bytes, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, err
-	}
-
-	drv, err := parseDerivation(bytes)
-	if err != nil {
-		return nil, err
-	}
-
-	return drv, drv.Validate()
 }

--- a/pkg/derivation/derivation_test.go
+++ b/pkg/derivation/derivation_test.go
@@ -145,24 +145,6 @@ func TestEncoder(t *testing.T) {
 	})
 }
 
-func TestOutputs(t *testing.T) {
-	drv := &derivation.Derivation{
-		Outputs: map[string]*derivation.Output{
-			"foo": {
-				Path: "dummy",
-			},
-			"bar": {
-				Path: "dummy2",
-			},
-		},
-	}
-
-	t.Run("String", func(t *testing.T) {
-		// TODO: replace with Drv path eventually
-		assert.Equal(t, "TODO", drv.String())
-	})
-}
-
 func TestValidate(t *testing.T) {
 	getDerivation := func() *derivation.Derivation {
 		derivationFile, err := os.Open("../../test/testdata/cl5fr6hlr6hdqza2vgb9qqy5s26wls8i-jq-1.6.drv")

--- a/pkg/derivation/derivation_test.go
+++ b/pkg/derivation/derivation_test.go
@@ -15,74 +15,39 @@ func TestParser(t *testing.T) {
 	cases := []struct {
 		Title          string
 		DerivationFile string
-		Output         *derivation.Output
+		Outputs        map[string]*derivation.Output
 		Platform       string
 		Builder        string
-		EnvVars        []derivation.Env
+		Env            map[string]string
 	}{
 		{
 			"Basic",
 			"m5j1yp47lw1psd9n6bzina1167abbprr-bash44-023.drv",
 			//			"basic.drv",
-			&derivation.Output{
-				Name:          "out",
-				Path:          "/nix/store/x9cyj78gzd1wjf0xsiad1pa3ricbj566-bash44-023",
-				HashAlgorithm: "sha256",
-				Hash:          "4fec236f3fbd3d0c47b893fdfa9122142a474f6ef66c20ffb6c0f4864dd591b6",
+			map[string]*derivation.Output{
+				"out": {
+					Path:          "/nix/store/x9cyj78gzd1wjf0xsiad1pa3ricbj566-bash44-023",
+					HashAlgorithm: "sha256",
+					Hash:          "4fec236f3fbd3d0c47b893fdfa9122142a474f6ef66c20ffb6c0f4864dd591b6",
+				},
 			},
+
 			"builtin",
 			"builtin:fetchurl",
-			[]derivation.Env{
-				{
-					Key:   "builder",
-					Value: "builtin:fetchurl",
-				},
-				{
-					Key: "executable",
-				},
-				{
-					Key:   "impureEnvVars",
-					Value: "http_proxy https_proxy ftp_proxy all_proxy no_proxy",
-				},
-				{
-					Key:   "name",
-					Value: "bash44-023",
-				},
-				{
-					Key:   "out",
-					Value: "/nix/store/x9cyj78gzd1wjf0xsiad1pa3ricbj566-bash44-023",
-				},
-				{
-					Key:   "outputHash",
-					Value: "1dlism6qdx60nvzj0v7ndr7lfahl4a8zmzckp13hqgdx7xpj7v2g",
-				},
-				{
-					Key:   "outputHashAlgo",
-					Value: "sha256",
-				},
-				{
-					Key:   "outputHashMode",
-					Value: "flat",
-				},
-				{
-					Key:   "preferLocalBuild",
-					Value: "1",
-				},
-				{
-					Key:   "system",
-					Value: "builtin",
-				},
-				{
-					Key: "unpack",
-				},
-				{
-					Key:   "url",
-					Value: "https://ftpmirror.gnu.org/bash/bash-4.4-patches/bash44-023",
-				},
-				{
-					Key:   "urls",
-					Value: "https://ftpmirror.gnu.org/bash/bash-4.4-patches/bash44-023",
-				},
+			map[string]string{
+				"builder":          "builtin:fetchurl",
+				"executable":       "",
+				"impureEnvVars":    "http_proxy https_proxy ftp_proxy all_proxy no_proxy",
+				"name":             "bash44-023",
+				"out":              "/nix/store/x9cyj78gzd1wjf0xsiad1pa3ricbj566-bash44-023",
+				"outputHash":       "1dlism6qdx60nvzj0v7ndr7lfahl4a8zmzckp13hqgdx7xpj7v2g",
+				"outputHashAlgo":   "sha256",
+				"outputHashMode":   "flat",
+				"preferLocalBuild": "1",
+				"system":           "builtin",
+				"unpack":           "",
+				"url":              "https://ftpmirror.gnu.org/bash/bash-4.4-patches/bash44-023",
+				"urls":             "https://ftpmirror.gnu.org/bash/bash-4.4-patches/bash44-023",
 			},
 		},
 	}
@@ -96,13 +61,10 @@ func TestParser(t *testing.T) {
 				}
 
 				drv, err := derivation.ReadDerivation(derivationFile)
-				if err != nil {
-					panic(err)
-				}
-				// repr.Println(drv, repr.Indent("  "), repr.OmitEmpty(true))
-				assert.Equal(t, &drv.Outputs[0], c.Output)
-				assert.Equal(t, drv.Builder, c.Builder)
-				assert.Equal(t, drv.EnvVars, c.EnvVars)
+				assert.NoError(t, err, "parsing derivation %s shouldn't fail", derivationFile)
+				assert.Equal(t, c.Outputs, drv.Outputs)
+				assert.Equal(t, c.Builder, drv.Builder)
+				assert.Equal(t, c.Env, drv.Env)
 			})
 		}
 	})
@@ -177,7 +139,7 @@ func TestEncoder(t *testing.T) {
 					panic(err)
 				}
 
-				assert.Equal(t, sb.String(), string(derivationBytes))
+				assert.Equal(t, string(derivationBytes), sb.String())
 			})
 		}
 	})
@@ -185,20 +147,19 @@ func TestEncoder(t *testing.T) {
 
 func TestOutputs(t *testing.T) {
 	drv := &derivation.Derivation{
-		Outputs: []derivation.Output{
-			{
-				Name: "foo",
+		Outputs: map[string]*derivation.Output{
+			"foo": {
 				Path: "dummy",
 			},
-			{
-				Name: "bar",
+			"bar": {
 				Path: "dummy2",
 			},
 		},
 	}
 
 	t.Run("String", func(t *testing.T) {
-		assert.Equal(t, "dummy", drv.String())
+		// TODO: replace with Drv path eventually
+		assert.Equal(t, "TODO", drv.String())
 	})
 }
 
@@ -221,7 +182,7 @@ func TestValidate(t *testing.T) {
 		t.Run("NoOutputsAtAll", func(t *testing.T) {
 			drv := getDerivation()
 
-			drv.Outputs = []derivation.Output{}
+			drv.Outputs = map[string]*derivation.Output{}
 
 			err := drv.Validate()
 			assert.Error(t, err)
@@ -237,7 +198,10 @@ func TestValidate(t *testing.T) {
 		t.Run("NoOutputName", func(t *testing.T) {
 			drv := getDerivation()
 
-			drv.Outputs[0].Name = ""
+			// rename key of bin to ""
+			binOutput := drv.Outputs["bin"]
+			delete(drv.Outputs, "bin")
+			drv.Outputs[""] = binOutput
 
 			err := drv.Validate()
 			assert.Error(t, err)
@@ -253,7 +217,7 @@ func TestValidate(t *testing.T) {
 		t.Run("InvalidPath", func(t *testing.T) {
 			drv := getDerivation()
 
-			drv.Outputs[0].Path = "invalidPath"
+			drv.Outputs["bin"].Path = "invalidPath"
 
 			err := drv.Validate()
 			assert.Error(t, err)
@@ -263,22 +227,6 @@ func TestValidate(t *testing.T) {
 				err.Error(),
 				"unable to parse path",
 				"error should complain about path syntax",
-			)
-		})
-
-		t.Run("InvalidOrder", func(t *testing.T) {
-			drv := getDerivation()
-
-			drv.Outputs[0].Name = "foo"
-
-			err := drv.Validate()
-			assert.Error(t, err)
-
-			assert.Containsf(
-				t,
-				err.Error(),
-				"invalid output order",
-				"error should complain about output order",
 			)
 		})
 	})
@@ -287,7 +235,14 @@ func TestValidate(t *testing.T) {
 		t.Run("InvalidPath", func(t *testing.T) {
 			drv := getDerivation()
 
-			drv.InputDerivations[0].Path = "bar"
+			// the first input derivation, and re-insert it with an empty key.
+			k := "/nix/store/073gancjdr3z1scm2p553v0k3cxj2cpy-fix-tests-when-building-without-regex-supports.patch.drv"
+			firstInputDrv, ok := drv.InputDerivations[k]
+			if !ok {
+				panic("missing key")
+			}
+			delete(drv.InputDerivations, k)
+			drv.InputDerivations[""] = firstInputDrv
 
 			err := drv.Validate()
 			assert.Error(t, err)
@@ -297,23 +252,6 @@ func TestValidate(t *testing.T) {
 				err.Error(),
 				"unable to parse path",
 				"error should complain about path syntax",
-			)
-		})
-
-		t.Run("InvalidOrder", func(t *testing.T) {
-			drv := getDerivation()
-
-			drv.InputDerivations[0].Path = "/nix/store/5k1sfc5qmzb93addcjxxnqcd5bpf2wlz-hook.drv"
-			drv.InputDerivations[1].Path = "/nix/store/4k1sfc5qmzb93addcjxxnqcd5bpf2wlz-hook.drv"
-
-			err := drv.Validate()
-			assert.Error(t, err)
-
-			assert.Containsf(
-				t,
-				err.Error(),
-				"invalid input derivation order",
-				"error should complain about ordering",
 			)
 		})
 	})
@@ -332,23 +270,6 @@ func TestValidate(t *testing.T) {
 				err.Error(),
 				"unable to parse path",
 				"error should complain about path syntax",
-			)
-		})
-
-		t.Run("InvalidOrder", func(t *testing.T) {
-			drv := getDerivation()
-
-			drv.InputSources[0] = "/nix/store/5k1sfc5qmzb93addcjxxnqcd5bpf2wlz-hook.drv"
-			drv.InputSources = append(drv.InputSources, "/nix/store/4k1sfc5qmzb93addcjxxnqcd5bpf2wlz-hook.drv")
-
-			err := drv.Validate()
-			assert.Error(t, err)
-
-			assert.Containsf(
-				t,
-				err.Error(),
-				"invalid input source order",
-				"error should complain about ordering",
 			)
 		})
 	})
@@ -386,27 +307,10 @@ func TestValidate(t *testing.T) {
 	})
 
 	t.Run("InvalidEnvVar", func(t *testing.T) {
-		t.Run("InvalidOrder", func(t *testing.T) {
-			drv := getDerivation()
-
-			drv.EnvVars[0].Key = "foo"
-			drv.EnvVars[1].Key = "bar"
-
-			err := drv.Validate()
-			assert.Error(t, err)
-
-			assert.Containsf(
-				t,
-				err.Error(),
-				"invalid env var order",
-				"error should complain about ordering",
-			)
-		})
-
 		t.Run("EmpyEnvVar", func(t *testing.T) {
 			drv := getDerivation()
 
-			drv.EnvVars[0].Key = ""
+			drv.Env[""] = "foo"
 
 			err := drv.Validate()
 			assert.Error(t, err)


### PR DESCRIPTION
A lot of the struct structure has been designed to work with the parser
generator we used.

Since https://github.com/nix-community/go-nix/pull/55 we have our own parser, so we can be a bit more flexible with
how the structure of the Derivation struct looks like.

Use the structure that's exposed when invoking `nix show-derivation`,
and peeking at the JSON there.

Outputs, InputDerivations and Env are maps, not lists with odd order
requirements. The Parser takes care of ensuring the order was correct
when parsing it in, and the encoder outputs them in the way things
should be sorted.

This makes the Validate() method much smaller, as there's simply less
invalid states someone manually populating the struct could produce.