### PR TITLE
pkg/derivation: add DrvPath() function

### DIFF
--- a/pkg/derivation/derivation_test.go
+++ b/pkg/derivation/derivation_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/nix-community/go-nix/pkg/derivation"
+	"github.com/nix-community/go-nix/pkg/nixpath"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -139,7 +141,13 @@ func TestEncoder(t *testing.T) {
 					panic(err)
 				}
 
-				assert.Equal(t, string(derivationBytes), sb.String())
+				assert.Equal(t, string(derivationBytes), sb.String(),
+					"encoded ATerm notation should match what's initially read from disk")
+
+				drvPath, err := drv.DrvPath()
+				assert.NoError(t, err, "calling DrvPath shouldn't error")
+				assert.Equal(t, filepath.Join(nixpath.StoreDir, c.DerivationFile), drvPath,
+					"drv path should be calculated correctly")
 			})
 		}
 	})

--- a/pkg/derivation/drvpath.go
+++ b/pkg/derivation/drvpath.go
@@ -1,0 +1,72 @@
+package derivation
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"sort"
+
+	"github.com/nix-community/go-nix/pkg/hash"
+	"github.com/nix-community/go-nix/pkg/nixbase32"
+	"github.com/nix-community/go-nix/pkg/nixpath"
+)
+
+func (d *Derivation) DrvPath() (string, error) {
+	// calculate the sha256 digest of the ATerm representation
+	h := sha256.New()
+
+	if err := d.WriteDerivation(h); err != nil {
+		return "", err
+	}
+
+	// store the atermDigest, we'll use it later
+	atermDigest := h.Sum(nil)
+
+	// reset the sha256 calculator
+	h = sha256.New()
+
+	h.Write([]byte("text:"))
+
+	// Write references (lexicographically ordered)
+	{
+		references := make([]string, len(d.InputDerivations)+len(d.InputSources))
+
+		n := 0
+
+		for inputDrvPath := range d.InputDerivations {
+			references[n] = inputDrvPath
+			n++
+		}
+
+		for _, inputSrc := range d.InputSources {
+			references[n] = inputSrc
+			n++
+		}
+
+		sort.Strings(references)
+
+		for _, ref := range references {
+			h.Write([]byte(ref))
+			h.Write([]byte{':'})
+		}
+	}
+
+	h.Write([]byte("sha256:"))
+	h.Write([]byte(hex.EncodeToString(atermDigest) + ":"))
+	h.Write([]byte(nixpath.StoreDir + ":"))
+
+	name, ok := d.Env["name"]
+	if !ok {
+		// asserted by Validate
+		panic("env 'name' not found")
+	}
+
+	h.Write([]byte(name + ".drv"))
+
+	atermDigest = h.Sum(nil)
+
+	return filepath.Join(
+		nixpath.StoreDir,
+		nixbase32.EncodeToString(hash.CompressHash(atermDigest, 20))+"-"+name+".drv",
+	), nil
+}

--- a/pkg/hash/util.go
+++ b/pkg/hash/util.go
@@ -1,0 +1,15 @@
+package hash
+
+// CompressHash takes an arbitrary long sequence of bytes (usually a hash digest),
+// and returns a sequence of bytes of length newSize.
+// It's calculated by rotating through the bytes in the output buffer (zero-initialized),
+// and XOR'ing with each byte in the passed input
+// It consumes 1 byte at a time, and XOR's it with the current value in the output buffer.
+func CompressHash(input []byte, outputSize int) []byte {
+	buf := make([]byte, outputSize)
+	for i := 0; i < len(input); i++ {
+		buf[i%outputSize] ^= input[i]
+	}
+
+	return buf
+}


### PR DESCRIPTION
This returns the path of a Drv, just by looking at its structure.