### PR TITLE
pkg/nixpath/references: Add a build output reference scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,8 @@ providing some of the functions in `encoding/base32.Encoding`.
 ## `pkg/nixpath`
 A parser and regexes for Nix Store Paths.
 
+## `pkg/nixpath/references`
+A Nix Store path reference scanner.
+
 ## `pkg/wire`
 Methods to parse and produce fields used in the low-level Nix wire protocol.

--- a/pkg/nixpath/references/refs.go
+++ b/pkg/nixpath/references/refs.go
@@ -1,0 +1,105 @@
+package references
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/nix-community/go-nix/pkg/nixbase32"
+	"github.com/nix-community/go-nix/pkg/nixpath"
+)
+
+const (
+	storePrefixLength = len(nixpath.StoreDir) + 1
+	refLength         = len(nixbase32.Alphabet) // Store path hash prefix length
+)
+
+// nolint:gochecknoglobals
+// This creates an array to check if a given byte is in the Nix base32 alphabet.
+var isNixBase32 = func() (arr [256]bool) {
+	for _, c := range nixbase32.Alphabet {
+		arr[c] = true
+	}
+
+	return
+}()
+
+// ReferenceScanner scans a stream of data for references to store paths to extract run time dependencies.
+type ReferenceScanner struct {
+	// Map of store path hashes to full store paths.
+	hashes map[string]string
+
+	// Set of hits.
+	hits map[string]struct{}
+
+	// Buffer for current partial hit.
+	buf [refLength]byte
+
+	// How far into buf is currently written.
+	n int
+}
+
+func NewReferenceScanner(storePathCandidates []string) (*ReferenceScanner, error) {
+	var buf [refLength]byte
+
+	hashes := make(map[string]string)
+
+	for _, storePath := range storePathCandidates {
+		if !strings.HasPrefix(storePath, nixpath.StoreDir) {
+			return nil, fmt.Errorf("missing store path prefix: %s", storePath)
+		}
+
+		// Check length is a valid store path length including dashes
+		if len(storePath) < len(nixpath.StoreDir)+refLength+3 {
+			return nil, fmt.Errorf("invalid store path length: %d for store path '%s'", len(storePath), storePath)
+		}
+
+		hashes[storePath[storePrefixLength:storePrefixLength+refLength]] = storePath
+	}
+
+	return &ReferenceScanner{
+		hits:   make(map[string]struct{}),
+		hashes: hashes,
+		buf:    buf,
+		n:      0,
+	}, nil
+}
+
+func (r *ReferenceScanner) References() []string {
+	paths := make([]string, len(r.hits))
+
+	i := 0
+
+	for hash := range r.hits {
+		paths[i] = r.hashes[hash]
+		i++
+	}
+
+	sort.Strings(paths)
+
+	return paths
+}
+
+func (r *ReferenceScanner) Write(s []byte) (int, error) {
+	for _, c := range s {
+		if !isNixBase32[c] {
+			r.n = 0
+
+			continue
+		}
+
+		r.buf[r.n] = c
+		r.n++
+
+		if r.n == refLength {
+			hash := string(r.buf[:])
+			if _, ok := r.hashes[hash]; ok {
+				r.hits[hash] = struct{}{}
+			}
+
+			r.n = 0
+		}
+	}
+
+	return len(s), nil
+}

--- a/pkg/nixpath/references/refs_test.go
+++ b/pkg/nixpath/references/refs_test.go
@@ -1,0 +1,66 @@
+package references_test
+
+import (
+	"testing"
+
+	"github.com/nix-community/go-nix/pkg/nixpath/references"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReferences(t *testing.T) {
+	cases := []struct {
+		Title    string
+		Chunks   []string
+		Expected []string
+	}{
+		{
+			Title: "Basic",
+			Chunks: []string{
+				"/nix/store/knn6wc1a89c47yb70qwv56rmxylia6wx-hello-2.12/bin/hello",
+			},
+			Expected: []string{
+				"/nix/store/knn6wc1a89c47yb70qwv56rmxylia6wx-hello-2.12",
+			},
+		},
+		{
+			Title: "PartialWrites",
+			Chunks: []string{
+				"/nix/store/knn6wc1a89c47yb70",
+				"qwv56rmxylia6wx-hello-2.12/bin/hello",
+			},
+			Expected: []string{
+				"/nix/store/knn6wc1a89c47yb70qwv56rmxylia6wx-hello-2.12",
+			},
+		},
+		{
+			Title: "IgnoredPaths",
+			Chunks: []string{
+				"/nix/store/knn6wc1a89c47yb70qwv56rmxylia6wx-hello-2.12/bin/hello",
+				"/nix/store/c4pcgriqgiwz8vxrjxg7p38q3y7w3ni3-go-1.18.2/bin/go",
+			},
+			Expected: []string{
+				"/nix/store/knn6wc1a89c47yb70qwv56rmxylia6wx-hello-2.12",
+			},
+		},
+	}
+
+	t.Run("ScanReferences", func(t *testing.T) {
+		for _, c := range cases {
+			t.Run(c.Title, func(t *testing.T) {
+				refScanner, err := references.NewReferenceScanner(c.Expected)
+				if err != nil {
+					panic(err)
+				}
+
+				for _, line := range c.Chunks {
+					_, err = refScanner.Write([]byte(line))
+					if err != nil {
+						panic(err)
+					}
+				}
+
+				assert.Equal(t, c.Expected, refScanner.References())
+			})
+		}
+	})
+}


### PR DESCRIPTION
This is largely a port of the algorithm that Nix uses but adapted to work with streaming data of unbounded length.