### PR TITLE
test/testdata: document how fixtures are produced, fix json serialization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Mark json files inside test/testdata as binary,
+# so git won't replace \n with \r\n on windows.
+test/testdata/*.json binary

--- a/pkg/derivation/derivation.go
+++ b/pkg/derivation/derivation.go
@@ -10,20 +10,24 @@ import (
 // Nix requires some stronger properties w.r.t. order of elements, so we can internally use
 // maps for some of the fields, and convert to the canonical representation when encoding back
 // to ATerm format.
-// The field names also match the json structure that the `nix show-derivation /path/to.drv` is using.
+// The field names (and order of fields) also match the json structure
+// that the `nix show-derivation /path/to.drv` is using,
+// even though this might change in the future.
 type Derivation struct {
 	// Outputs are always lexicographically sorted by their name (key in this map)
 	Outputs map[string]*Output `json:"outputs"`
+
+	// InputSources are always lexicographically sorted.
+	InputSources []string `json:"inputSrcs"`
 
 	// InputDerivations are always lexicographically sorted by their path (key in this map)
 	// the []string returns the output names (out, …) of this input derivation that are used.
 	InputDerivations map[string][]string `json:"inputDrvs"`
 
-	// InputSources are always lexicographically sorted.
-	InputSources []string `json:"inputSrcs"`
+	Platform string `json:"system"`
 
-	Platform  string   `json:"system"`
-	Builder   string   `json:"builder"`
+	Builder string `json:"builder"`
+
 	Arguments []string `json:"args"`
 
 	// Env must be lexicographically sorted by their key.

--- a/pkg/derivation/json_test.go
+++ b/pkg/derivation/json_test.go
@@ -1,0 +1,68 @@
+package derivation_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nix-community/go-nix/pkg/derivation"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestJSONSerialize serializes a Derivation to a JSON,
+// and verifies it matches what `nix show-derivation` shows.
+// As the Nix output uses the Derivation Path as a key, we
+// serialize the map instead.
+func TestJSONSerialize(t *testing.T) {
+	drvs := []string{"0hm2f1psjpcwg8fijsmr4wwxrx59s092-bar.drv", "4wvvbi4jwn0prsdxb7vs673qa5h9gr7x-foo.drv"}
+
+	for _, drvBasename := range drvs {
+		container := make(map[string]*derivation.Derivation)
+
+		derivationFile, err := os.Open(filepath.FromSlash("../../test/testdata/" + drvBasename))
+		if err != nil {
+			panic(err)
+		}
+
+		derivationBytes, err := io.ReadAll(derivationFile)
+		if err != nil {
+			panic(err)
+		}
+
+		drv, err := derivation.ReadDerivation(bytes.NewReader(derivationBytes))
+		if err != nil {
+			panic(err)
+		}
+
+		drvPath, err := drv.DrvPath()
+		if err != nil {
+			panic(err)
+		}
+
+		container[drvPath] = drv
+
+		var buf bytes.Buffer
+
+		enc := json.NewEncoder(&buf)
+		enc.SetIndent("", "  ")
+
+		err = enc.Encode(container)
+		assert.NoError(t, err, "encoding a derivation to JSON shouldn't error")
+
+		// compare the output with the prerecorded json output
+		derivationJSONFile, err := os.Open(filepath.FromSlash("../../test/testdata/" + drvBasename + ".json"))
+		if err != nil {
+			panic(err)
+		}
+
+		derivationJSONBytes, err := io.ReadAll(derivationJSONFile)
+		if err != nil {
+			panic(err)
+		}
+
+		assert.Equal(t, derivationJSONBytes, buf.Bytes(), "encoded json should match pre-recorded output")
+	}
+}

--- a/pkg/derivation/output.go
+++ b/pkg/derivation/output.go
@@ -6,8 +6,8 @@ import (
 
 type Output struct {
 	Path          string `json:"path"`
-	HashAlgorithm string `json:"hashAlgo"`
-	Hash          string `json:"hash"`
+	HashAlgorithm string `json:"hashAlgo,omitempty"`
+	Hash          string `json:"hash,omitempty"`
 }
 
 func (o *Output) Validate() error {

--- a/pkg/derivation/parser.go
+++ b/pkg/derivation/parser.go
@@ -45,6 +45,10 @@ func parseDerivation(derivationBytes []byte) (*Derivation, error) {
 
 	drv := &Derivation{}
 
+	// https://github.com/golang/go/issues/37711
+	drv.InputSources = []string{}
+	drv.Arguments = []string{}
+
 	err := arrayEach(derivationBytes[6:], func(value []byte, index int) error {
 		var err error
 

--- a/test/testdata/0hm2f1psjpcwg8fijsmr4wwxrx59s092-bar.drv.json
+++ b/test/testdata/0hm2f1psjpcwg8fijsmr4wwxrx59s092-bar.drv.json
@@ -1,0 +1,25 @@
+{
+  "/nix/store/0hm2f1psjpcwg8fijsmr4wwxrx59s092-bar.drv": {
+    "outputs": {
+      "out": {
+        "path": "/nix/store/4q0pg5zpfmznxscq3avycvf9xdvx50n3-bar",
+        "hashAlgo": "r:sha256",
+        "hash": "08813cbee9903c62be4c5027726a418a300da4500b2d369d3af9286f4815ceba"
+      }
+    },
+    "inputSrcs": [],
+    "inputDrvs": {},
+    "system": ":",
+    "builder": ":",
+    "args": [],
+    "env": {
+      "builder": ":",
+      "name": "bar",
+      "out": "/nix/store/4q0pg5zpfmznxscq3avycvf9xdvx50n3-bar",
+      "outputHash": "08813cbee9903c62be4c5027726a418a300da4500b2d369d3af9286f4815ceba",
+      "outputHashAlgo": "sha256",
+      "outputHashMode": "recursive",
+      "system": ":"
+    }
+  }
+}

--- a/test/testdata/4wvvbi4jwn0prsdxb7vs673qa5h9gr7x-foo.drv.json
+++ b/test/testdata/4wvvbi4jwn0prsdxb7vs673qa5h9gr7x-foo.drv.json
@@ -1,0 +1,25 @@
+{
+  "/nix/store/4wvvbi4jwn0prsdxb7vs673qa5h9gr7x-foo.drv": {
+    "outputs": {
+      "out": {
+        "path": "/nix/store/5vyvcwah9l9kf07d52rcgdk70g2f4y13-foo"
+      }
+    },
+    "inputSrcs": [],
+    "inputDrvs": {
+      "/nix/store/0hm2f1psjpcwg8fijsmr4wwxrx59s092-bar.drv": [
+        "out"
+      ]
+    },
+    "system": ":",
+    "builder": ":",
+    "args": [],
+    "env": {
+      "bar": "/nix/store/4q0pg5zpfmznxscq3avycvf9xdvx50n3-bar",
+      "builder": ":",
+      "name": "foo",
+      "out": "/nix/store/5vyvcwah9l9kf07d52rcgdk70g2f4y13-foo",
+      "system": ":"
+    }
+  }
+}

--- a/test/testdata/build_fixtures.sh
+++ b/test/testdata/build_fixtures.sh
@@ -16,3 +16,15 @@ foo=$(nix-instantiate derivation_sha256.nix -A foo)
 cp $foo .
 foo_json_path=$(basename $foo).json
 nix show-derivation $foo > $foo_json_path
+
+# /nix/store/ss2p4wmxijn652haqyd7dckxwl4c7hxx-bar.drv
+bar=$(nix-instantiate derivation_sha1.nix -A bar)
+cp $bar .
+bar_json_path=$(basename $bar).json
+nix show-derivation $bar > $bar_json_path
+
+# /nix/store/ch49594n9avinrf8ip0aslidkc4lxkqv-foo.drv
+foo=$(nix-instantiate derivation_sha1.nix -A foo)
+cp $foo .
+foo_json_path=$(basename $foo).json
+nix show-derivation $foo > $foo_json_path

--- a/test/testdata/build_fixtures.sh
+++ b/test/testdata/build_fixtures.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# This (re-)builds a bunch of fixture files from this folder.
+
+# It requires the following binaries to be in $PATH:
+# - nix-instantiate
+
+# /nix/store/0hm2f1psjpcwg8fijsmr4wwxrx59s092-bar.drv
+bar=$(nix-instantiate derivation_sha256.nix -A bar)
+cp $bar .
+
+# /nix/store/4wvvbi4jwn0prsdxb7vs673qa5h9gr7x-foo.drv
+foo=$(nix-instantiate derivation_sha256.nix -A foo)
+cp $foo .

--- a/test/testdata/build_fixtures.sh
+++ b/test/testdata/build_fixtures.sh
@@ -8,7 +8,11 @@
 # /nix/store/0hm2f1psjpcwg8fijsmr4wwxrx59s092-bar.drv
 bar=$(nix-instantiate derivation_sha256.nix -A bar)
 cp $bar .
+bar_json_path=$(basename $bar).json
+nix show-derivation $bar > $bar_json_path
 
 # /nix/store/4wvvbi4jwn0prsdxb7vs673qa5h9gr7x-foo.drv
 foo=$(nix-instantiate derivation_sha256.nix -A foo)
 cp $foo .
+foo_json_path=$(basename $foo).json
+nix show-derivation $foo > $foo_json_path

--- a/test/testdata/derivation_sha1.nix
+++ b/test/testdata/derivation_sha1.nix
@@ -1,0 +1,17 @@
+rec {
+  bar = builtins.derivation {
+    name = "bar";
+    builder = ":";
+    system = ":";
+    outputHash = "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33";
+    outputHashAlgo = "sha1";
+    outputHashMode = "recursive";
+  };
+
+  foo = builtins.derivation {
+    name = "foo";
+    builder = ":";
+    system = ":";
+    inherit bar;
+  };
+}

--- a/test/testdata/derivation_sha256.nix
+++ b/test/testdata/derivation_sha256.nix
@@ -1,0 +1,17 @@
+rec {
+  bar = builtins.derivation {
+    name = "bar";
+    builder = ":";
+    system = ":";
+    outputHash = "08813cbee9903c62be4c5027726a418a300da4500b2d369d3af9286f4815ceba";
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  };
+
+  foo = builtins.derivation {
+    name = "foo";
+    builder = ":";
+    system = ":";
+    inherit bar;
+  };
+}


### PR DESCRIPTION
Committing the original nix source files will allow reproducing test
fixtures both with Nix, as well as eventually our own implementation,
providing a nice closed loop.

This also fixes JSON serialization to match the output of `nix show-derivation`, and adds a test for it.