### PR TITLE
pkg/derivation/store: add HTTPStore, FSStore, CLI tooling

### DIFF
--- a/cmd/gonix/drv/cmd.go
+++ b/cmd/gonix/drv/cmd.go
@@ -11,16 +11,16 @@ import (
 )
 
 type Cmd struct {
-	StorageDir string `kong:"default='',help='Path where derivations are read from.'"`
-	drvStore   derivation.Store
+	DrvStoreURI string `kong:"name='drv-store',default='',help='URI to a Derivation Store'"`
+	drvStore    derivation.Store
 
 	Show ShowCmd `kong:"cmd,name='show',help='Show a derivation'"`
 }
 
 func (cmd *Cmd) AfterApply() error {
-	drvStore, err := derivationStore.NewFSStore(cmd.StorageDir)
+	drvStore, err := derivationStore.NewFromURI(cmd.DrvStoreURI)
 	if err != nil {
-		return fmt.Errorf("error initializing store: %w", err)
+		return fmt.Errorf("error creating store from URI: %w", err)
 	}
 
 	cmd.drvStore = drvStore

--- a/cmd/gonix/drv/cmd.go
+++ b/cmd/gonix/drv/cmd.go
@@ -1,0 +1,63 @@
+package drv
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/nix-community/go-nix/pkg/derivation"
+	derivationStore "github.com/nix-community/go-nix/pkg/derivation/store"
+)
+
+type Cmd struct {
+	StorageDir string `kong:"default='',help='Path where derivations are read from.'"`
+	drvStore   derivation.Store
+
+	Show ShowCmd `kong:"cmd,name='show',help='Show a derivation'"`
+}
+
+func (cmd *Cmd) AfterApply() error {
+	drvStore, err := derivationStore.NewFSStore(cmd.StorageDir)
+	if err != nil {
+		return fmt.Errorf("error initializing store: %w", err)
+	}
+
+	cmd.drvStore = drvStore
+
+	return nil
+}
+
+type ShowCmd struct {
+	Drv    string `kong:"arg,type='string',help='Path to the Derivation'"`
+	Format string `kong:"default='json-pretty',help='The format to use to show (aterm,json-pretty,json)'"`
+}
+
+func (cmd *ShowCmd) Run(drvCmd *Cmd) error {
+	drvStore := drvCmd.drvStore
+
+	drv, err := drvStore.Get(context.Background(), cmd.Drv)
+	if err != nil {
+		return err
+	}
+
+	switch cmd.Format {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		err = enc.Encode(drv)
+	case "json-pretty":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		err = enc.Encode(drv)
+	case "aterm":
+		err = drv.WriteDerivation(os.Stdout)
+	default:
+		err = fmt.Errorf("invalid format: %v", cmd.Format)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/gonix/drv/cmd.go
+++ b/cmd/gonix/drv/cmd.go
@@ -7,25 +7,12 @@ import (
 	"os"
 
 	"github.com/nix-community/go-nix/pkg/derivation"
-	derivationStore "github.com/nix-community/go-nix/pkg/derivation/store"
 )
 
 type Cmd struct {
-	DrvStoreURI string `kong:"name='drv-store',default='',help='URI to a Derivation Store'"`
-	drvStore    derivation.Store
+	DrvStore derivation.Store `kong:"type='drv-store-uri',default='',help='Path where derivations are read from.'"`
 
 	Show ShowCmd `kong:"cmd,name='show',help='Show a derivation'"`
-}
-
-func (cmd *Cmd) AfterApply() error {
-	drvStore, err := derivationStore.NewFromURI(cmd.DrvStoreURI)
-	if err != nil {
-		return fmt.Errorf("error creating store from URI: %w", err)
-	}
-
-	cmd.drvStore = drvStore
-
-	return nil
 }
 
 type ShowCmd struct {
@@ -34,7 +21,7 @@ type ShowCmd struct {
 }
 
 func (cmd *ShowCmd) Run(drvCmd *Cmd) error {
-	drvStore := drvCmd.drvStore
+	drvStore := drvCmd.DrvStore
 
 	drv, err := drvStore.Get(context.Background(), cmd.Drv)
 	if err != nil {

--- a/cmd/gonix/drv_store_uri_mapper.go
+++ b/cmd/gonix/drv_store_uri_mapper.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/alecthomas/kong"
+	derivationStore "github.com/nix-community/go-nix/pkg/derivation/store"
+)
+
+func drvStoreURIDecoder() kong.MapperFunc {
+	return func(ctx *kong.DecodeContext, target reflect.Value) error {
+		var drvStoreURI string
+
+		err := ctx.Scan.PopValueInto("value", &drvStoreURI)
+		if err != nil {
+			return err
+		}
+
+		drvStore, err := derivationStore.NewFromURI(drvStoreURI)
+		if err != nil {
+			return fmt.Errorf("error creating store from URI: %w", err)
+		}
+
+		target.Set(reflect.ValueOf(drvStore))
+
+		return nil
+	}
+}

--- a/cmd/gonix/main.go
+++ b/cmd/gonix/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/alecthomas/kong"
 	"github.com/nix-community/go-nix/cmd/gonix/drv"
 	"github.com/nix-community/go-nix/cmd/gonix/nar"
@@ -13,9 +15,17 @@ var cli struct {
 }
 
 func main() {
-	ctx := kong.Parse(&cli)
+	parser, err := kong.New(&cli, kong.NamedMapper("drv-store-uri", drvStoreURIDecoder()))
+	if err != nil {
+		panic(err)
+	}
+
+	ctx, err := parser.Parse(os.Args[1:])
+	if err != nil {
+		panic(err)
+	}
 	// Call the Run() method of the selected parsed command.
-	err := ctx.Run()
+	err = ctx.Run()
 
 	ctx.FatalIfErrorf(err)
 }

--- a/cmd/gonix/main.go
+++ b/cmd/gonix/main.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"github.com/alecthomas/kong"
+	"github.com/nix-community/go-nix/cmd/gonix/drv"
 	"github.com/nix-community/go-nix/cmd/gonix/nar"
 )
 
 // nolint:gochecknoglobals
 var cli struct {
 	Nar nar.Cmd `kong:"cmd,name='nar',help='Create or inspect NAR files'"`
+	Drv drv.Cmd `kong:"cmd,name='drv',help='Inspect NAR files'"`
 }
 
 func main() {

--- a/pkg/derivation/store/filesystem.go
+++ b/pkg/derivation/store/filesystem.go
@@ -1,0 +1,100 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/nix-community/go-nix/pkg/derivation"
+	"github.com/nix-community/go-nix/pkg/nixpath"
+)
+
+// FSStore implements derivation.Store.
+var _ derivation.Store = &FSStore{}
+
+// NewFSStore returns a store exposing all `.drv` files in the directory
+// specified by storageDir.
+// If storageDir is set to an empty string, nixpath.StoreDir is used as a directory.
+func NewFSStore(storageDir string) (*FSStore, error) {
+	if storageDir == "" {
+		storageDir = nixpath.StoreDir
+	}
+
+	return &FSStore{
+		StorageDir: storageDir,
+	}, nil
+}
+
+// FSStore provides a derivation.Store interface,
+// that exposes all .drv files in a given folder.
+// These files need to be regular files, not symlinks.
+// It doesn't do any output path validation and consistency checks,
+// meaning you usually want to wrap this in a validating store.
+// Right now, Put() is not implemented.
+type FSStore struct {
+	// The path containing the .drv files on disk
+	StorageDir string
+}
+
+// Put is not implemented right now.
+func (fs *FSStore) Put(ctx context.Context, drv *derivation.Derivation) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+// getFilepath returns the path to a .drv file,
+// with respect to the configured StorageDir.
+func (fs *FSStore) getFilepath(derivationPath string) string {
+	return filepath.Join(fs.StorageDir, path.Base(derivationPath))
+}
+
+// Get retrieves a Derivation by drv path from the Derivation Store.
+func (fs *FSStore) Get(ctx context.Context, derivationPath string) (*derivation.Derivation, error) {
+	path := fs.getFilepath(derivationPath)
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	drv, err := derivation.ReadDerivation(f)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse derivation: %w", err)
+	}
+
+	return drv, nil
+}
+
+// Has returns whether the derivation (by drv path) exists.
+// We only need pass this down to the cache, as everything
+// we did Get() is stored in there.
+func (fs *FSStore) Has(ctx context.Context, derivationPath string) (bool, error) {
+	path := fs.getFilepath(derivationPath)
+
+	// Stat the file. We do an lstat here, to not follow symlinks.
+	fi, err := os.Lstat(path)
+	if err != nil {
+		// if stat returns os.ErrNotExits, this means the file doesn't exist.
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+
+		// in all other cases, stat returned an error.
+		return false, fmt.Errorf("unable to stat %s: %w", path, err)
+	}
+
+	// We already have `fi`, so do a quick check the file is regular.
+	if isRegular := fi.Mode().IsRegular(); !isRegular {
+		return false, fmt.Errorf("file at %s is not regular", path)
+	}
+
+	// otherwise, assume it's fine.
+	return true, nil
+}
+
+// Close is a no-op.
+func (fs *FSStore) Close() error {
+	return nil
+}

--- a/pkg/derivation/store/filesystem_test.go
+++ b/pkg/derivation/store/filesystem_test.go
@@ -1,0 +1,41 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nix-community/go-nix/pkg/derivation/store"
+	"github.com/nix-community/go-nix/pkg/nixpath"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFSStore(t *testing.T) {
+	cases := []struct {
+		Title          string
+		DerivationFile string
+	}{
+		{
+			Title:          "fixed-sha256",
+			DerivationFile: "0hm2f1psjpcwg8fijsmr4wwxrx59s092-bar.drv",
+		},
+		{
+			// Has a single fixed-output dependency
+			Title:          "simple-sha256",
+			DerivationFile: "4wvvbi4jwn0prsdxb7vs673qa5h9gr7x-foo.drv",
+		},
+	}
+
+	// Initialize the FSStore
+	drvStore, err := store.NewFSStore("../../../test/testdata/")
+	if err != nil {
+		panic(err)
+	}
+
+	for _, c := range cases {
+		t.Run(c.Title, func(t *testing.T) {
+			drvPath := nixpath.Absolute(c.DerivationFile)
+			_, err := drvStore.Get(context.Background(), drvPath)
+			assert.NoError(t, err, "Get(%v) shouldn't error", c.DerivationFile)
+		})
+	}
+}

--- a/pkg/derivation/store/http.go
+++ b/pkg/derivation/store/http.go
@@ -1,0 +1,139 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/nix-community/go-nix/pkg/derivation"
+)
+
+// HTTPStore implements derivation.Store.
+var _ derivation.Store = &HTTPStore{}
+
+// NewHTTPStore returns a HTTPStore with a given base URL.
+func NewHTTPStore(baseURL *url.URL) *HTTPStore {
+	return &HTTPStore{
+		Client:  &http.Client{},
+		BaseURL: baseURL,
+	}
+}
+
+// HTTPStore provides a store exposing all .drv files
+// directly hosted below the a HTTP path specified by baseURL
+// aka ${baseURl}/${base derivationPath}.
+// It doesn't do any output path validation and consistency checks,
+// meaning you usually want to wrap this in a validating store.
+// Right now, Put() is not implemented.
+type HTTPStore struct {
+	Client *http.Client
+	// The base URL
+	BaseURL *url.URL
+}
+
+// Put is not implemented right now.
+func (hs *HTTPStore) Put(ctx context.Context, drv *derivation.Derivation) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+// getURL returns the full url to a derivation path,
+// with respect to the configured BaseURL.
+// It constructs the URL by appending the derivation path,
+// cleaned by nixpath.StoreDir.
+func (hs *HTTPStore) getURL(derivationPath string) url.URL {
+	// copy the base url
+	url := *hs.BaseURL
+	url.Path = path.Join(url.Path, path.Base(derivationPath))
+
+	return url
+}
+
+// constructRequest constructs a http.Request, based on a derivation path.
+func (hs *HTTPStore) constructRequest(
+	ctx context.Context,
+	method string,
+	derivationPath string,
+) (*http.Request, error) {
+	u := hs.getURL(derivationPath)
+
+	// construct the request
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error constructing request: %w", err)
+	}
+
+	return req, nil
+}
+
+// Get retrieves a Derivation by drv path from the Derivation Store.
+func (hs *HTTPStore) Get(ctx context.Context, derivationPath string) (*derivation.Derivation, error) {
+	req, err := hs.constructRequest(ctx, "GET", derivationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := hs.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error doing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("bad status code: %v", resp.StatusCode)
+	}
+
+	// prepare a buffer to receive the body in
+	var buf bytes.Buffer
+
+	// copy body into buffer
+	_, err = io.Copy(&buf, resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading body: %w", err)
+	}
+
+	// parse derivation from the buffer
+	drv, err := derivation.ReadDerivation(&buf)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing derivation: %w", err)
+	}
+
+	return drv, nil
+}
+
+// Has returns whether the derivation (by drv path) exists.
+// It does this by doing a HEAD request to the http endpoint.
+func (hs *HTTPStore) Has(ctx context.Context, derivationPath string) (bool, error) {
+	req, err := hs.constructRequest(ctx, "HEAD", derivationPath)
+	if err != nil {
+		return false, err
+	}
+
+	resp, err := hs.Client.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("error doing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// if we get back a plain 404, this means the file doesn't exist.
+	if resp.StatusCode == 404 {
+		return false, nil
+	}
+
+	// if we get back something in the 2xx range, this means
+	// the file exists
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return true, nil
+	}
+
+	// else, return an error
+	return false, fmt.Errorf("bad status code: %v", resp.StatusCode)
+}
+
+// Close is a no-op.
+func (hs *HTTPStore) Close() error {
+	return nil
+}

--- a/pkg/derivation/store/uri.go
+++ b/pkg/derivation/store/uri.go
@@ -13,7 +13,7 @@ import (
 //  - http:// and https:// initialize an HTTPStore
 //  - badger:// initializes an in-memory badger store.
 //  - badger:///path/to/badger initializes an on-disk badger store.
-func NewFromURI(uri string) (derivation.Store, error) {
+func NewFromURI(uri string) (derivation.Store, error) { // nolint:ireturn
 	u, err := url.Parse(uri)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse uri: %w", err)

--- a/pkg/derivation/store/uri.go
+++ b/pkg/derivation/store/uri.go
@@ -1,0 +1,36 @@
+package store
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/nix-community/go-nix/pkg/derivation"
+)
+
+// NewFromURI returns a derivation.Store by consuming a URI:
+//  - if no scheme is specified, FSStore is assumed
+//  - file:// also uses FSStore.
+//  - http:// and https:// initialize an HTTPStore
+//  - badger:// initializes an in-memory badger store.
+//  - badger:///path/to/badger initializes an on-disk badger store.
+func NewFromURI(uri string) (derivation.Store, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse uri: %w", err)
+	}
+
+	switch u.Scheme {
+	case "":
+		return NewFSStore(u.Path)
+	case "badger":
+		return NewBadgerStore("")
+	case "file":
+		return NewFSStore(u.Path)
+	case "http":
+		return NewHTTPStore(u), nil
+	case "https":
+		return NewHTTPStore(u), nil
+	default:
+		return nil, fmt.Errorf("unknown scheme: %v", u.Scheme)
+	}
+}


### PR DESCRIPTION
~This depends on https://github.com/nix-community/go-nix/pull/64 and should be rebased once merged.~ Part of this was already in #58, but excluded from #63.

It introduces `pkg/derivation/store.{HTTPStore,FSStore}`, a `store.NewFromURI` method, and a `gonix drv --drv-store=uri-goes-here show /nix/store/drv-path.drv` command.

`{HTTPStore,FSStore}` don't implement any checking of output paths and referred derivations to exist, but I intend to provide this functionality via some "proxy store", that can be used to cache "remote" `derivation.Store` into a local one, and rely on the local store checks (left as a followup)