### PR TITLE
pkg/nixpath: Reduce allocations when validating

### DIFF
--- a/pkg/derivation/derivation.go
+++ b/pkg/derivation/derivation.go
@@ -71,7 +71,7 @@ func (d *Derivation) Validate() error {
 	}
 
 	for inputDerivationPath := range d.InputDerivations {
-		_, err := nixpath.FromString(inputDerivationPath)
+		err := nixpath.Validate(inputDerivationPath)
 		if err != nil {
 			return err
 		}
@@ -93,7 +93,7 @@ func (d *Derivation) Validate() error {
 	}
 
 	for i, is := range d.InputSources {
-		_, err := nixpath.FromString(is)
+		err := nixpath.Validate(is)
 		if err != nil {
 			return fmt.Errorf("error validating input source '%s': %w", is, err)
 		}

--- a/pkg/derivation/output.go
+++ b/pkg/derivation/output.go
@@ -11,10 +11,5 @@ type Output struct {
 }
 
 func (o *Output) Validate() error {
-	_, err := nixpath.FromString(o.Path)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return nixpath.Validate(o.Path)
 }

--- a/pkg/nixbase32/nixbase32_test.go
+++ b/pkg/nixbase32/nixbase32_test.go
@@ -41,6 +41,14 @@ func TestDecode(t *testing.T) {
 	}
 }
 
+func TestValidate(t *testing.T) {
+	for i := range tt {
+		err := nixbase32.ValidateString(tt[i].enc)
+
+		assert.NoError(t, err)
+	}
+}
+
 func TestMustDecodeString(t *testing.T) {
 	for i := range tt {
 		b := nixbase32.MustDecodeString(tt[i].enc)
@@ -59,6 +67,9 @@ func TestDecodeInvalid(t *testing.T) {
 
 	for _, c := range invalidEncodings {
 		_, err := nixbase32.DecodeString(c)
+		assert.Error(t, err)
+
+		err = nixbase32.ValidateString(c)
 		assert.Error(t, err)
 
 		assert.Panics(t, func() {

--- a/pkg/nixpath/nixpath_test.go
+++ b/pkg/nixpath/nixpath_test.go
@@ -27,17 +27,32 @@ func TestNixPath(t *testing.T) {
 	})
 
 	t.Run("invalid hash length", func(t *testing.T) {
-		_, err := nixpath.FromString("/nix/store/00bgd045z0d4icpbc2yy-net-tools-1.60_p20170221182432")
+		s := "/nix/store/00bgd045z0d4icpbc2yy-net-tools-1.60_p20170221182432"
+
+		_, err := nixpath.FromString(s)
+		assert.Error(t, err)
+
+		err = nixpath.Validate(s)
 		assert.Error(t, err)
 	})
 
 	t.Run("invalid encoding in hash", func(t *testing.T) {
-		_, err := nixpath.FromString("/nix/store/00bgd045z0d4icpbc2yyz4gx48aku4la-net-tools-1.60_p20170221182432")
+		s := "/nix/store/00bgd045z0d4icpbc2yyz4gx48aku4la-net-tools-1.60_p20170221182432"
+
+		_, err := nixpath.FromString(s)
+		assert.Error(t, err)
+
+		err = nixpath.Validate(s)
 		assert.Error(t, err)
 	})
 
 	t.Run("more than just the bare nix store path", func(t *testing.T) {
-		_, err := nixpath.FromString("/nix/store/00bgd045z0d4icpbc2yyz4gx48aku4la-net-tools-1.60_p20170221182432/bin/arp")
+		s := "/nix/store/00bgd045z0d4icpbc2yyz4gx48aku4la-net-tools-1.60_p20170221182432/bin/arp"
+
+		_, err := nixpath.FromString(s)
+		assert.Error(t, err)
+
+		err = nixpath.Validate(s)
 		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/nix-community/go-nix/pull/77.

This ensures we don't have to do costly allocations for every store path that we validate when validating a derivation.

The following test program:
``` go
package main

import (
	"bytes"
	"fmt"
	"io"
	"os"
	"testing"
	"time"

	"github.com/nix-community/go-nix/pkg/derivation"
)

func main() {

	drvPath := "/nix/store/lfb109iifgph2xa94aps13n2w8bpbqsq-texlive-combined-full-2021-final.drv"

	n := 50

	derivationFile, err := os.Open(drvPath)
	if err != nil {
		panic(err)
	}

	drvBytes, err := io.ReadAll(derivationFile)
	if err != nil {
		panic(err)
	}

	{
		start := time.Now()

		for i := 0; i < n; i++ {
			_, err := derivation.ReadDerivation(bytes.NewReader(drvBytes))
			if err != nil {
				panic(err)
			}
		}

		fmt.Println(time.Since(start) / time.Duration(n))
	}

	fmt.Println("Allocs:", int(testing.AllocsPerRun(n, func() {
		_, err := derivation.ReadDerivation(bytes.NewReader(drvBytes))
		if err != nil {
			panic(err)
		}
	})))

}
```

Yields the following numbers:
- Before
```
14.045441ms
Allocs: 27304
```

- After
```
8.503212ms
Allocs: 11864
```