### PR TITLE
pkg/derivation: Use unsafe to cast from []byte to string

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
-# Mark json files inside test/testdata as binary,
+# Mark everything inside test/testdata as binary,
 # so git won't replace \n with \r\n on windows.
-test/testdata/*.json binary
+test/testdata/* binary
+test/testdata/*.go binary diff

--- a/pkg/derivation/derivation_test.go
+++ b/pkg/derivation/derivation_test.go
@@ -151,6 +151,10 @@ func TestEncoder(t *testing.T) {
 			Title:          "latin1",
 			DerivationFile: "x6p0hg79i3wg0kkv7699935f7rrj9jf3-latin1.drv",
 		},
+		{
+			Title:          "cp1252",
+			DerivationFile: "m1vfixn8iprlf0v9abmlrz7mjw1xj8kp-cp1252.drv",
+		},
 	}
 
 	t.Run("WriteDerivation", func(t *testing.T) {
@@ -397,6 +401,10 @@ func TestDrvPath(t *testing.T) {
 		{
 			Title:          "latin1",
 			DerivationFile: "x6p0hg79i3wg0kkv7699935f7rrj9jf3-latin1.drv",
+		},
+		{
+			Title:          "cp1252",
+			DerivationFile: "m1vfixn8iprlf0v9abmlrz7mjw1xj8kp-cp1252.drv",
 		},
 	}
 

--- a/pkg/derivation/derivation_test.go
+++ b/pkg/derivation/derivation_test.go
@@ -147,6 +147,10 @@ func TestEncoder(t *testing.T) {
 			Title:          "unicode",
 			DerivationFile: "52a9id8hx688hvlnz4d1n25ml1jdykz0-unicode.drv",
 		},
+		{
+			Title:          "latin1",
+			DerivationFile: "x6p0hg79i3wg0kkv7699935f7rrj9jf3-latin1.drv",
+		},
 	}
 
 	t.Run("WriteDerivation", func(t *testing.T) {
@@ -389,6 +393,10 @@ func TestDrvPath(t *testing.T) {
 		{
 			Title:          "unicode",
 			DerivationFile: "52a9id8hx688hvlnz4d1n25ml1jdykz0-unicode.drv",
+		},
+		{
+			Title:          "latin1",
+			DerivationFile: "x6p0hg79i3wg0kkv7699935f7rrj9jf3-latin1.drv",
 		},
 	}
 

--- a/pkg/derivation/derivation_test.go
+++ b/pkg/derivation/derivation_test.go
@@ -143,6 +143,10 @@ func TestEncoder(t *testing.T) {
 			Title:          "structured-attrs",
 			DerivationFile: "9lj1lkjm2ag622mh4h9rpy6j607an8g2-structured-attrs.drv",
 		},
+		{
+			Title:          "unicode",
+			DerivationFile: "52a9id8hx688hvlnz4d1n25ml1jdykz0-unicode.drv",
+		},
 	}
 
 	t.Run("WriteDerivation", func(t *testing.T) {
@@ -381,6 +385,10 @@ func TestDrvPath(t *testing.T) {
 		{
 			Title:          "structured-attrs",
 			DerivationFile: "9lj1lkjm2ag622mh4h9rpy6j607an8g2-structured-attrs.drv",
+		},
+		{
+			Title:          "unicode",
+			DerivationFile: "52a9id8hx688hvlnz4d1n25ml1jdykz0-unicode.drv",
 		},
 	}
 

--- a/test/testdata/52a9id8hx688hvlnz4d1n25ml1jdykz0-unicode.drv
+++ b/test/testdata/52a9id8hx688hvlnz4d1n25ml1jdykz0-unicode.drv
@@ -1,0 +1,1 @@
+Derive([("out","/nix/store/vgvdj6nf7s8kvfbl2skbpwz9kc7xjazc-unicode","","")],[],[],":",":",[],[("builder",":"),("letters","räksmörgås\nrødgrød med fløde\nLübeck\n肥猪\nこんにちは / 今日は\n🌮\n"),("name","unicode"),("out","/nix/store/vgvdj6nf7s8kvfbl2skbpwz9kc7xjazc-unicode"),("system",":")])

--- a/test/testdata/52a9id8hx688hvlnz4d1n25ml1jdykz0-unicode.drv.json
+++ b/test/testdata/52a9id8hx688hvlnz4d1n25ml1jdykz0-unicode.drv.json
@@ -1,0 +1,21 @@
+{
+  "/nix/store/52a9id8hx688hvlnz4d1n25ml1jdykz0-unicode.drv": {
+    "outputs": {
+      "out": {
+        "path": "/nix/store/vgvdj6nf7s8kvfbl2skbpwz9kc7xjazc-unicode"
+      }
+    },
+    "inputSrcs": [],
+    "inputDrvs": {},
+    "system": ":",
+    "builder": ":",
+    "args": [],
+    "env": {
+      "builder": ":",
+      "letters": "räksmörgås\nrødgrød med fløde\nLübeck\n肥猪\nこんにちは / 今日は\n🌮\n",
+      "name": "unicode",
+      "out": "/nix/store/vgvdj6nf7s8kvfbl2skbpwz9kc7xjazc-unicode",
+      "system": ":"
+    }
+  }
+}

--- a/test/testdata/cp1252.nix
+++ b/test/testdata/cp1252.nix
@@ -1,0 +1,6 @@
+builtins.derivation {
+  name = "cp1252";
+  builder = ":";
+  system = ":";
+  chars = "ÅÄÖ";
+}

--- a/test/testdata/latin1.nix
+++ b/test/testdata/latin1.nix
@@ -1,0 +1,6 @@
+builtins.derivation {
+  name = "latin1";
+  builder = ":";
+  system = ":";
+  chars = "ÅÄÖ";
+}

--- a/test/testdata/m1vfixn8iprlf0v9abmlrz7mjw1xj8kp-cp1252.drv
+++ b/test/testdata/m1vfixn8iprlf0v9abmlrz7mjw1xj8kp-cp1252.drv
@@ -1,0 +1,1 @@
+Derive([("out","/nix/store/drr2mjp9fp9vvzsf5f9p0a80j33dxy7m-cp1252","","")],[],[],":",":",[],[("builder",":"),("chars","едж"),("name","cp1252"),("out","/nix/store/drr2mjp9fp9vvzsf5f9p0a80j33dxy7m-cp1252"),("system",":")])

--- a/test/testdata/m1vfixn8iprlf0v9abmlrz7mjw1xj8kp-cp1252.drv.json
+++ b/test/testdata/m1vfixn8iprlf0v9abmlrz7mjw1xj8kp-cp1252.drv.json
@@ -1,0 +1,21 @@
+{
+  "/nix/store/m1vfixn8iprlf0v9abmlrz7mjw1xj8kp-cp1252.drv": {
+    "outputs": {
+      "out": {
+        "path": "/nix/store/drr2mjp9fp9vvzsf5f9p0a80j33dxy7m-cp1252"
+      }
+    },
+    "inputSrcs": [],
+    "inputDrvs": {},
+    "system": ":",
+    "builder": ":",
+    "args": [],
+    "env": {
+      "builder": ":",
+      "chars": "ÅÄÖ",
+      "name": "cp1252",
+      "out": "/nix/store/drr2mjp9fp9vvzsf5f9p0a80j33dxy7m-cp1252",
+      "system": ":"
+    }
+  }
+}

--- a/test/testdata/unicode.nix
+++ b/test/testdata/unicode.nix
@@ -1,0 +1,13 @@
+builtins.derivation {
+  name = "unicode";
+  builder = ":";
+  system = ":";
+  letters = ''
+    räksmörgås
+    rødgrød med fløde
+    Lübeck
+    肥猪
+    こんにちは / 今日は
+    🌮
+  '';
+}

--- a/test/testdata/x6p0hg79i3wg0kkv7699935f7rrj9jf3-latin1.drv
+++ b/test/testdata/x6p0hg79i3wg0kkv7699935f7rrj9jf3-latin1.drv
@@ -1,0 +1,1 @@
+Derive([("out","/nix/store/x1f6jfq9qgb6i8jrmpifkn9c64fg4hcm-latin1","","")],[],[],":",":",[],[("builder",":"),("chars","едж"),("name","latin1"),("out","/nix/store/x1f6jfq9qgb6i8jrmpifkn9c64fg4hcm-latin1"),("system",":")])

--- a/test/testdata/x6p0hg79i3wg0kkv7699935f7rrj9jf3-latin1.drv.json
+++ b/test/testdata/x6p0hg79i3wg0kkv7699935f7rrj9jf3-latin1.drv.json
@@ -1,0 +1,21 @@
+{
+  "/nix/store/x6p0hg79i3wg0kkv7699935f7rrj9jf3-latin1.drv": {
+    "outputs": {
+      "out": {
+        "path": "/nix/store/x1f6jfq9qgb6i8jrmpifkn9c64fg4hcm-latin1"
+      }
+    },
+    "inputSrcs": [],
+    "inputDrvs": {},
+    "system": ":",
+    "builder": ":",
+    "args": [],
+    "env": {
+      "builder": ":",
+      "chars": "ÅÄÖ",
+      "name": "latin1",
+      "out": "/nix/store/x1f6jfq9qgb6i8jrmpifkn9c64fg4hcm-latin1",
+      "system": ":"
+    }
+  }
+}


### PR DESCRIPTION
This ensures no copying.

The following test program:
``` go
package main

import (
	"bytes"
	"fmt"
	"io"
	"os"
	"testing"
	"time"

	"github.com/nix-community/go-nix/pkg/derivation"
)

func main() {

	drvPath := "/nix/store/lfb109iifgph2xa94aps13n2w8bpbqsq-texlive-combined-full-2021-final.drv"

	n := 50

	derivationFile, err := os.Open(drvPath)
	if err != nil {
		panic(err)
	}

	drvBytes, err := io.ReadAll(derivationFile)
	if err != nil {
		panic(err)
	}

	{
		start := time.Now()

		for i := 0; i < n; i++ {
			_, err := derivation.ReadDerivation(bytes.NewReader(drvBytes))
			if err != nil {
				panic(err)
			}
		}

		fmt.Println(time.Since(start) / time.Duration(n))
	}

	fmt.Println("Allocs:", int(testing.AllocsPerRun(n, func() {
		_, err := derivation.ReadDerivation(bytes.NewReader(drvBytes))
		if err != nil {
			panic(err)
		}
	})))

}
```

Yields these numbers:
- Before:
```
13.011372ms
Allocs: 27305
```

- After:
```
12.119679ms
Allocs: 19537
```