### PR TITLE
pkg/nar: drop TypeUnknown

### DIFF
--- a/pkg/nar/dump.go
+++ b/pkg/nar/dump.go
@@ -59,7 +59,7 @@ func dumpPath(nw *Writer, path string, subpath string, filter SourceFilterFunc) 
 	} else if fi.Mode().IsRegular() {
 		nodeType = TypeRegular
 	} else {
-		nodeType = TypeUnknown
+		return fmt.Errorf("unknown type for %v", p)
 	}
 
 	if filter != nil && !filter(p, nodeType) {
@@ -144,9 +144,7 @@ func dumpPath(nw *Writer, path string, subpath string, filter SourceFilterFunc) 
 		}
 
 		return nil
-
-	case TypeUnknown:
 	}
 
-	return fmt.Errorf("invalid mode for file %v", p)
+	return fmt.Errorf("unknown type for file %v", p)
 }

--- a/pkg/nar/dump_nonwindows_test.go
+++ b/pkg/nar/dump_nonwindows_test.go
@@ -28,5 +28,5 @@ func TestDumpPathUnknown(t *testing.T) {
 
 	err = nar.DumpPath(&buf, p)
 	assert.Error(t, err)
-	assert.Containsf(t, err.Error(), "invalid mode", "error should complain about invalid mode")
+	assert.Containsf(t, err.Error(), "unknown type", "error should complain about unknown type")
 }

--- a/pkg/nar/header.go
+++ b/pkg/nar/header.go
@@ -32,11 +32,6 @@ func (h *Header) Validate() error {
 		return fmt.Errorf("path may not contain null bytes")
 	}
 
-	// Constructing a NAR with TypeUnknown is invalid
-	if h.Type == TypeUnknown {
-		return fmt.Errorf("type is unknown")
-	}
-
 	// Regular files and directories may not have LinkTarget set.
 	if h.Type == TypeRegular || h.Type == TypeDirectory {
 		if h.LinkTarget != "" {

--- a/pkg/nar/header_mode.go
+++ b/pkg/nar/header_mode.go
@@ -23,10 +23,6 @@ func (fi headerFileInfo) Mode() fs.FileMode {
 		mode |= (syscall.S_IXUSR | syscall.S_IXGRP | syscall.S_IXOTH)
 	case TypeSymlink:
 		mode = fs.ModePerm | fs.ModeSymlink
-	case TypeUnknown:
-		// It's not possible to create a NAR with a member of TypeUnknown using either
-		// the reader or the writer, only by manually populating structs.
-		panic("No mode for TypeUnknown")
 	}
 
 	return mode

--- a/pkg/nar/header_mode_windows.go
+++ b/pkg/nar/header_mode_windows.go
@@ -19,10 +19,6 @@ func (fi headerFileInfo) Mode() fs.FileMode {
 		mode = fs.ModeDir
 	case TypeSymlink:
 		mode = fs.ModeSymlink
-	case TypeUnknown:
-		// It's not possible to create a NAR with a member of TypeUnknown using either
-		// the reader or the writer, only by manually populating structs.
-		panic("No mode for TypeUnknown")
 	}
 
 	return mode & ^fs.FileMode(0200)

--- a/pkg/nar/types.go
+++ b/pkg/nar/types.go
@@ -12,8 +12,6 @@ const (
 	TypeDirectory = NodeType("directory")
 	// TypeSymlink represents a file symlink.
 	TypeSymlink = NodeType("symlink")
-	// TypeUnknown represents an unknown file (such as device nodes or fifos).
-	TypeUnknown = NodeType("unknown")
 )
 
 func (t NodeType) String() string {


### PR DESCRIPTION
Simply return an error when stumbling over something unknown during
DumpPath.