### PR TITLE
go-nix drv show: match behavior of `nix show-derivation`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     name: Build (Go ${{ matrix.go }}, OS ${{ matrix.os }})
     steps:
     - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v17
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,7 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
+    - name: ensure fixtures are in /nix/store
+      run: bash -c 'cd test/testdata && ./build-fixtures.go'
     - name: go test -race -bench='.+' -v ./...
       run: go test -race -bench='.+' -v ./...

--- a/cmd/gonix/drv/cmd.go
+++ b/cmd/gonix/drv/cmd.go
@@ -29,10 +29,12 @@ func (cmd *ShowCmd) Run(drvCmd *Cmd) error {
 	}
 
 	container := make(map[string]*derivation.Derivation)
+
 	drvPath, err := drv.DrvPath()
 	if err != nil {
 		return err
 	}
+
 	container[drvPath] = drv
 
 	switch cmd.Format {

--- a/cmd/gonix/drv/cmd.go
+++ b/cmd/gonix/drv/cmd.go
@@ -38,9 +38,11 @@ func (cmd *ShowCmd) Run(drvCmd *Cmd) error {
 	switch cmd.Format {
 	case "json":
 		enc := json.NewEncoder(os.Stdout)
+		enc.SetEscapeHTML(false)
 		err = enc.Encode(container)
 	case "json-pretty":
 		enc := json.NewEncoder(os.Stdout)
+		enc.SetEscapeHTML(false)
 		enc.SetIndent("", "  ")
 		err = enc.Encode(container)
 	case "aterm":

--- a/cmd/gonix/drv/cmd.go
+++ b/cmd/gonix/drv/cmd.go
@@ -28,14 +28,21 @@ func (cmd *ShowCmd) Run(drvCmd *Cmd) error {
 		return err
 	}
 
+	container := make(map[string]*derivation.Derivation)
+	drvPath, err := drv.DrvPath()
+	if err != nil {
+		return err
+	}
+	container[drvPath] = drv
+
 	switch cmd.Format {
 	case "json":
 		enc := json.NewEncoder(os.Stdout)
-		err = enc.Encode(drv)
+		err = enc.Encode(container)
 	case "json-pretty":
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		err = enc.Encode(drv)
+		err = enc.Encode(container)
 	case "aterm":
 		err = drv.WriteDerivation(os.Stdout)
 	default:

--- a/cmd/gonix/main_test.go
+++ b/cmd/gonix/main_test.go
@@ -21,10 +21,10 @@ func TestDrvShow(t *testing.T) {
 		oldOut := os.Stdout
 		os.Stdout = pw
 		var buf bytes.Buffer
-		err_pipe := make(chan error, 1)
+		errPipe := make(chan error, 1)
 		go func() {
 			_, err := io.Copy(&buf, pr)
-			err_pipe <- err
+			errPipe <- err
 		}()
 		main()
 		os.Stdout = oldOut
@@ -32,7 +32,7 @@ func TestDrvShow(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		err = <- err_pipe
+		err = <- errPipe
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/gonix/main_test.go
+++ b/cmd/gonix/main_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDrvShow tests the `go-nix drv show` command.
+func TestDrvShow(t *testing.T) {
+	drvs := []string {"../../test/testdata/7dsin4zpzi50wv7nia5nsi813nyrjgal-escape_html.drv"};
+	for _, drvBasename := range drvs {
+		os.Args = []string{"gonix", "drv", "show", ("../../test/testdata/" + drvBasename)}
+		pr, pw, err := os.Pipe()
+		if err != nil {
+			panic(err)
+		}
+		oldOut := os.Stdout
+		os.Stdout = pw
+		var buf bytes.Buffer
+		err_pipe := make(chan error, 1)
+		go func() {
+			_, err := io.Copy(&buf, pr)
+			err_pipe <- err
+		}()
+		main()
+		os.Stdout = oldOut
+		err = pw.Close()
+		if err != nil {
+			panic(err)
+		}
+		err = <- err_pipe
+		if err != nil {
+			panic(err)
+		}
+		// compare the output with the prerecorded json output
+		derivationJSONFile, err := os.Open(filepath.FromSlash("../../test/testdata/" + drvBasename + ".json"))
+		if err != nil {
+			panic(err)
+		}
+		derivationJSONBytes, err := io.ReadAll(derivationJSONFile)
+		if err != nil {
+			panic(err)
+		}
+		assert.Equal(t, derivationJSONBytes, buf.Bytes(), "encoded json should match pre-recorded output")
+	}
+}

--- a/cmd/gonix/main_test.go
+++ b/cmd/gonix/main_test.go
@@ -6,45 +6,58 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
 	"github.com/stretchr/testify/assert"
 )
 
 // TestDrvShow tests the `go-nix drv show` command.
 func TestDrvShow(t *testing.T) {
-	drvs := []string {"../../test/testdata/7dsin4zpzi50wv7nia5nsi813nyrjgal-escape_html.drv"};
+	drvs := []string{"../../test/testdata/7dsin4zpzi50wv7nia5nsi813nyrjgal-escape_html.drv"}
 	for _, drvBasename := range drvs {
 		os.Args = []string{"gonix", "drv", "show", ("../../test/testdata/" + drvBasename)}
+
 		pr, pw, err := os.Pipe()
 		if err != nil {
 			panic(err)
 		}
+
 		oldOut := os.Stdout
 		os.Stdout = pw
+
 		var buf bytes.Buffer
+
 		errPipe := make(chan error, 1)
+
 		go func() {
 			_, err := io.Copy(&buf, pr)
 			errPipe <- err
 		}()
 		main()
+
 		os.Stdout = oldOut
 		err = pw.Close()
+
 		if err != nil {
 			panic(err)
 		}
-		err = <- errPipe
+
+		err = <-errPipe
+
 		if err != nil {
 			panic(err)
 		}
+
 		// compare the output with the prerecorded json output
 		derivationJSONFile, err := os.Open(filepath.FromSlash("../../test/testdata/" + drvBasename + ".json"))
 		if err != nil {
 			panic(err)
 		}
+
 		derivationJSONBytes, err := io.ReadAll(derivationJSONFile)
 		if err != nil {
 			panic(err)
 		}
+
 		assert.Equal(t, derivationJSONBytes, buf.Bytes(), "encoded json should match pre-recorded output")
 	}
 }

--- a/test/testdata/7dsin4zpzi50wv7nia5nsi813nyrjgal-escape_html.drv
+++ b/test/testdata/7dsin4zpzi50wv7nia5nsi813nyrjgal-escape_html.drv
@@ -1,0 +1,1 @@
+Derive([("out","/nix/store/9v7q094f02la3j6m5iyk92p0yp8v3ijr-escape_html","","")],[],[],":","cat < /dev/urandom > /dev/audio",[],[("builder","cat < /dev/urandom > /dev/audio"),("name","escape_html"),("out","/nix/store/9v7q094f02la3j6m5iyk92p0yp8v3ijr-escape_html"),("system",":")])

--- a/test/testdata/7dsin4zpzi50wv7nia5nsi813nyrjgal-escape_html.drv.json
+++ b/test/testdata/7dsin4zpzi50wv7nia5nsi813nyrjgal-escape_html.drv.json
@@ -1,0 +1,20 @@
+{
+  "/nix/store/7dsin4zpzi50wv7nia5nsi813nyrjgal-escape_html.drv": {
+    "outputs": {
+      "out": {
+        "path": "/nix/store/9v7q094f02la3j6m5iyk92p0yp8v3ijr-escape_html"
+      }
+    },
+    "inputSrcs": [],
+    "inputDrvs": {},
+    "system": ":",
+    "builder": "cat < /dev/urandom > /dev/audio",
+    "args": [],
+    "env": {
+      "builder": "cat < /dev/urandom > /dev/audio",
+      "name": "escape_html",
+      "out": "/nix/store/9v7q094f02la3j6m5iyk92p0yp8v3ijr-escape_html",
+      "system": ":"
+    }
+  }
+}

--- a/test/testdata/build-fixtures.go
+++ b/test/testdata/build-fixtures.go
@@ -56,6 +56,10 @@ var fixtures = []*fixture{
 		path: "/nix/store/9lj1lkjm2ag622mh4h9rpy6j607an8g2-structured-attrs.drv",
 		file: "derivation_structured.nix",
 	},
+	{
+		path: "/nix/store/7dsin4zpzi50wv7nia5nsi813nyrjgal-escape_html.drv",
+		file: "derivation_escape_html.nix",
+	},
 }
 
 func buildFixture(fixture *fixture) error {

--- a/test/testdata/derivation_escape_html.nix
+++ b/test/testdata/derivation_escape_html.nix
@@ -1,0 +1,5 @@
+builtins.derivation {
+  name = "escape_html";
+  builder = "cat < /dev/urandom > /dev/audio";
+  system = ":";
+}


### PR DESCRIPTION
CC: @flokli

Hopefully this isn't too awful; this is my first time writing Go, so take it easy on me...

This PR gets `go-nix drv show` to match the behavior of `nix show-derivation` in two cases where it didnt: escapification of HTML-escapables (`>`, `<`, etc) and wrapping the json with a top-level map whose key is the drvName.  It also adds a test covering HTML-escapables since none of the existing tests covered that case.

Looking back on this, matching cppnix's escaping behavior might be a WONTFIX.  No downstream json consumer should depend on whether or not characters are escaped  other than `\"`).  I can drop that patch from the PR if you prefer.