### PR TITLE
pkg/narinfo/signature: export Name and Data fields

### DIFF
--- a/pkg/narinfo/signature/public_key.go
+++ b/pkg/narinfo/signature/public_key.go
@@ -7,23 +7,23 @@ import (
 
 // PublicKey represents a named ed25519 public key.
 type PublicKey struct {
-	name string
-	data ed25519.PublicKey
+	Name string
+	Data ed25519.PublicKey
 }
 
 // String outputs a string representation as name + ":" + base64(data).
 func (pk PublicKey) String() string {
-	return encode(pk.name, pk.data)
+	return encode(pk.Name, pk.Data)
 }
 
 // Verify that the fingerprint with the signature against the public key. If the
 // signature and public key don't have the same name, just return false.
 func (pk PublicKey) Verify(fingerprint string, sig Signature) bool {
-	if pk.name != sig.name {
+	if pk.Name != sig.Name {
 		return false
 	}
 
-	return ed25519.Verify(pk.data, []byte(fingerprint), sig.data)
+	return ed25519.Verify(pk.Data, []byte(fingerprint), sig.Data)
 }
 
 // ParsePublicKey decodes a serialized string, and returns a PublicKey struct, or an error.

--- a/pkg/narinfo/signature/signature.go
+++ b/pkg/narinfo/signature/signature.go
@@ -7,13 +7,13 @@ import (
 
 // Signature represents a named ed25519 signature.
 type Signature struct {
-	name string
-	data []byte
+	Name string
+	Data []byte
 }
 
 // String returns the encoded <keyname>:<base64-signature-data>.
 func (s Signature) String() string {
-	return encode(s.name, s.data)
+	return encode(s.Name, s.Data)
 }
 
 // ParseSignature decodes a <keyname>:<base64-signature-data>
@@ -32,7 +32,7 @@ func ParseSignature(s string) (Signature, error) {
 func VerifyFirst(fingerprint string, signatures []Signature, pubKeys []PublicKey) bool {
 	for _, key := range pubKeys {
 		for _, sig := range signatures {
-			if key.name == sig.name {
+			if key.Name == sig.Name {
 				return key.Verify(fingerprint, sig)
 			}
 		}


### PR DESCRIPTION
This makes it easier to access them from the outside, which is useful when transforming into another data structure.