### PR TITLE
test/testdata: regenerate JSON files

### DIFF
--- a/cmd/gonix/drv/cmd.go
+++ b/cmd/gonix/drv/cmd.go
@@ -28,6 +28,9 @@ func (cmd *ShowCmd) Run(drvCmd *Cmd) error {
 		return err
 	}
 
+	// Keep in mind `nix show-derivation` started sorting all of the JSON alphabetically,
+	// while this still preserves the previous order of keys, as  encoding/json
+	// preserves struct element definition order when serializing.
 	switch cmd.Format {
 	case "json":
 		enc := json.NewEncoder(os.Stdout)

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-varint v0.0.6 // indirect
+	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/multiformats/go-multihash v0.2.1 h1:aem8ZT0VA2nCHHk7bPJ1BjUbHNciqZC/d
 github.com/multiformats/go-multihash v0.2.1/go.mod h1:WxoMcYG85AZVQUyRyo9s4wULvW5qrI9vb2Lt6evduFc=
 github.com/multiformats/go-varint v0.0.6 h1:gk85QWKxh3TazbLxED/NlDVv8+q+ReFJk7Y2W/KhfNY=
 github.com/multiformats/go-varint v0.0.6/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
+github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249 h1:NHrXEjTNQY7P0Zfx1aMrNhpgxHmow66XQtm0aQLY0AE=
+github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249/go.mod h1:mpRZBD8SJ55OIICQ3iWH0Yz3cjzA61JdqMLoWXeB2+8=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/derivation/json_test.go
+++ b/pkg/derivation/json_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/nix-community/go-nix/pkg/derivation"
+	"github.com/nsf/jsondiff"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -63,6 +64,16 @@ func TestJSONSerialize(t *testing.T) {
 			panic(err)
 		}
 
-		assert.Equal(t, derivationJSONBytes, buf.Bytes(), "encoded json should match pre-recorded output")
+		// encoding/json serializes in struct key definition order, not alphabetic.
+		// So we can't just compare the raw bytes unfortunately.
+		diffOpts := jsondiff.DefaultConsoleOptions()
+
+		diff, str := jsondiff.Compare(derivationJSONBytes, buf.Bytes(), &diffOpts)
+
+		assert.Equal(t, jsondiff.FullMatch, diff, "produced json should be equal")
+
+		if diff != jsondiff.FullMatch {
+			panic(str)
+		}
 	}
 }

--- a/test/testdata/0hm2f1psjpcwg8fijsmr4wwxrx59s092-bar.drv.json
+++ b/test/testdata/0hm2f1psjpcwg8fijsmr4wwxrx59s092-bar.drv.json
@@ -1,17 +1,7 @@
 {
   "/nix/store/0hm2f1psjpcwg8fijsmr4wwxrx59s092-bar.drv": {
-    "outputs": {
-      "out": {
-        "path": "/nix/store/4q0pg5zpfmznxscq3avycvf9xdvx50n3-bar",
-        "hashAlgo": "r:sha256",
-        "hash": "08813cbee9903c62be4c5027726a418a300da4500b2d369d3af9286f4815ceba"
-      }
-    },
-    "inputSrcs": [],
-    "inputDrvs": {},
-    "system": ":",
-    "builder": ":",
     "args": [],
+    "builder": ":",
     "env": {
       "builder": ":",
       "name": "bar",
@@ -20,6 +10,16 @@
       "outputHashAlgo": "sha256",
       "outputHashMode": "recursive",
       "system": ":"
-    }
+    },
+    "inputDrvs": {},
+    "inputSrcs": [],
+    "outputs": {
+      "out": {
+        "hash": "08813cbee9903c62be4c5027726a418a300da4500b2d369d3af9286f4815ceba",
+        "hashAlgo": "r:sha256",
+        "path": "/nix/store/4q0pg5zpfmznxscq3avycvf9xdvx50n3-bar"
+      }
+    },
+    "system": ":"
   }
 }

--- a/test/testdata/292w8yzv5nn7nhdpxcs8b7vby2p27s09-nested-json.drv.json
+++ b/test/testdata/292w8yzv5nn7nhdpxcs8b7vby2p27s09-nested-json.drv.json
@@ -1,21 +1,21 @@
 {
   "/nix/store/292w8yzv5nn7nhdpxcs8b7vby2p27s09-nested-json.drv": {
-    "outputs": {
-      "out": {
-        "path": "/nix/store/pzr7lsd3q9pqsnb42r9b23jc5sh8irvn-nested-json"
-      }
-    },
-    "inputSrcs": [],
-    "inputDrvs": {},
-    "system": ":",
-    "builder": ":",
     "args": [],
+    "builder": ":",
     "env": {
       "builder": ":",
       "json": "{\"hello\":\"moto\\n\"}",
       "name": "nested-json",
       "out": "/nix/store/pzr7lsd3q9pqsnb42r9b23jc5sh8irvn-nested-json",
       "system": ":"
-    }
+    },
+    "inputDrvs": {},
+    "inputSrcs": [],
+    "outputs": {
+      "out": {
+        "path": "/nix/store/pzr7lsd3q9pqsnb42r9b23jc5sh8irvn-nested-json"
+      }
+    },
+    "system": ":"
   }
 }

--- a/test/testdata/4wvvbi4jwn0prsdxb7vs673qa5h9gr7x-foo.drv.json
+++ b/test/testdata/4wvvbi4jwn0prsdxb7vs673qa5h9gr7x-foo.drv.json
@@ -1,25 +1,25 @@
 {
   "/nix/store/4wvvbi4jwn0prsdxb7vs673qa5h9gr7x-foo.drv": {
-    "outputs": {
-      "out": {
-        "path": "/nix/store/5vyvcwah9l9kf07d52rcgdk70g2f4y13-foo"
-      }
-    },
-    "inputSrcs": [],
-    "inputDrvs": {
-      "/nix/store/0hm2f1psjpcwg8fijsmr4wwxrx59s092-bar.drv": [
-        "out"
-      ]
-    },
-    "system": ":",
-    "builder": ":",
     "args": [],
+    "builder": ":",
     "env": {
       "bar": "/nix/store/4q0pg5zpfmznxscq3avycvf9xdvx50n3-bar",
       "builder": ":",
       "name": "foo",
       "out": "/nix/store/5vyvcwah9l9kf07d52rcgdk70g2f4y13-foo",
       "system": ":"
-    }
+    },
+    "inputDrvs": {
+      "/nix/store/0hm2f1psjpcwg8fijsmr4wwxrx59s092-bar.drv": [
+        "out"
+      ]
+    },
+    "inputSrcs": [],
+    "outputs": {
+      "out": {
+        "path": "/nix/store/5vyvcwah9l9kf07d52rcgdk70g2f4y13-foo"
+      }
+    },
+    "system": ":"
   }
 }

--- a/test/testdata/9lj1lkjm2ag622mh4h9rpy6j607an8g2-structured-attrs.drv.json
+++ b/test/testdata/9lj1lkjm2ag622mh4h9rpy6j607an8g2-structured-attrs.drv.json
@@ -1,18 +1,18 @@
 {
   "/nix/store/9lj1lkjm2ag622mh4h9rpy6j607an8g2-structured-attrs.drv": {
+    "args": [],
+    "builder": ":",
+    "env": {
+      "__json": "{\"builder\":\":\",\"name\":\"structured-attrs\",\"system\":\":\"}",
+      "out": "/nix/store/6a39dl014j57bqka7qx25k0vb20vkqm6-structured-attrs"
+    },
+    "inputDrvs": {},
+    "inputSrcs": [],
     "outputs": {
       "out": {
         "path": "/nix/store/6a39dl014j57bqka7qx25k0vb20vkqm6-structured-attrs"
       }
     },
-    "inputSrcs": [],
-    "inputDrvs": {},
-    "system": ":",
-    "builder": ":",
-    "args": [],
-    "env": {
-      "__json": "{\"builder\":\":\",\"name\":\"structured-attrs\",\"system\":\":\"}",
-      "out": "/nix/store/6a39dl014j57bqka7qx25k0vb20vkqm6-structured-attrs"
-    }
+    "system": ":"
   }
 }

--- a/test/testdata/ch49594n9avinrf8ip0aslidkc4lxkqv-foo.drv.json
+++ b/test/testdata/ch49594n9avinrf8ip0aslidkc4lxkqv-foo.drv.json
@@ -1,25 +1,25 @@
 {
   "/nix/store/ch49594n9avinrf8ip0aslidkc4lxkqv-foo.drv": {
-    "outputs": {
-      "out": {
-        "path": "/nix/store/fhaj6gmwns62s6ypkcldbaj2ybvkhx3p-foo"
-      }
-    },
-    "inputSrcs": [],
-    "inputDrvs": {
-      "/nix/store/ss2p4wmxijn652haqyd7dckxwl4c7hxx-bar.drv": [
-        "out"
-      ]
-    },
-    "system": ":",
-    "builder": ":",
     "args": [],
+    "builder": ":",
     "env": {
       "bar": "/nix/store/mp57d33657rf34lzvlbpfa1gjfv5gmpg-bar",
       "builder": ":",
       "name": "foo",
       "out": "/nix/store/fhaj6gmwns62s6ypkcldbaj2ybvkhx3p-foo",
       "system": ":"
-    }
+    },
+    "inputDrvs": {
+      "/nix/store/ss2p4wmxijn652haqyd7dckxwl4c7hxx-bar.drv": [
+        "out"
+      ]
+    },
+    "inputSrcs": [],
+    "outputs": {
+      "out": {
+        "path": "/nix/store/fhaj6gmwns62s6ypkcldbaj2ybvkhx3p-foo"
+      }
+    },
+    "system": ":"
   }
 }

--- a/test/testdata/h32dahq0bx5rp1krcdx3a53asj21jvhk-has-multi-out.drv.json
+++ b/test/testdata/h32dahq0bx5rp1krcdx3a53asj21jvhk-has-multi-out.drv.json
@@ -1,5 +1,17 @@
 {
   "/nix/store/h32dahq0bx5rp1krcdx3a53asj21jvhk-has-multi-out.drv": {
+    "args": [],
+    "builder": ":",
+    "env": {
+      "builder": ":",
+      "lib": "/nix/store/2vixb94v0hy2xc6p7mbnxxcyc095yyia-has-multi-out-lib",
+      "name": "has-multi-out",
+      "out": "/nix/store/55lwldka5nyxa08wnvlizyqw02ihy8ic-has-multi-out",
+      "outputs": "out lib",
+      "system": ":"
+    },
+    "inputDrvs": {},
+    "inputSrcs": [],
     "outputs": {
       "lib": {
         "path": "/nix/store/2vixb94v0hy2xc6p7mbnxxcyc095yyia-has-multi-out-lib"
@@ -8,18 +20,6 @@
         "path": "/nix/store/55lwldka5nyxa08wnvlizyqw02ihy8ic-has-multi-out"
       }
     },
-    "inputSrcs": [],
-    "inputDrvs": {},
-    "system": ":",
-    "builder": ":",
-    "args": [],
-    "env": {
-      "builder": ":",
-      "lib": "/nix/store/2vixb94v0hy2xc6p7mbnxxcyc095yyia-has-multi-out-lib",
-      "name": "has-multi-out",
-      "out": "/nix/store/55lwldka5nyxa08wnvlizyqw02ihy8ic-has-multi-out",
-      "outputs": "out lib",
-      "system": ":"
-    }
+    "system": ":"
   }
 }

--- a/test/testdata/ss2p4wmxijn652haqyd7dckxwl4c7hxx-bar.drv.json
+++ b/test/testdata/ss2p4wmxijn652haqyd7dckxwl4c7hxx-bar.drv.json
@@ -1,17 +1,7 @@
 {
   "/nix/store/ss2p4wmxijn652haqyd7dckxwl4c7hxx-bar.drv": {
-    "outputs": {
-      "out": {
-        "path": "/nix/store/mp57d33657rf34lzvlbpfa1gjfv5gmpg-bar",
-        "hashAlgo": "r:sha1",
-        "hash": "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"
-      }
-    },
-    "inputSrcs": [],
-    "inputDrvs": {},
-    "system": ":",
-    "builder": ":",
     "args": [],
+    "builder": ":",
     "env": {
       "builder": ":",
       "name": "bar",
@@ -20,6 +10,16 @@
       "outputHashAlgo": "sha1",
       "outputHashMode": "recursive",
       "system": ":"
-    }
+    },
+    "inputDrvs": {},
+    "inputSrcs": [],
+    "outputs": {
+      "out": {
+        "hash": "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33",
+        "hashAlgo": "r:sha1",
+        "path": "/nix/store/mp57d33657rf34lzvlbpfa1gjfv5gmpg-bar"
+      }
+    },
+    "system": ":"
   }
 }


### PR DESCRIPTION
It looks like the keys in `nix show-derivation` output were not sorted (but stable), and some Nix version update changed that.

Regenerate the JSON files to prevent CI from failing.