### PR TITLE
fix validation of sorted elements in list

### DIFF
--- a/pkg/derivation/derivation.go
+++ b/pkg/derivation/derivation.go
@@ -87,7 +87,7 @@ func (d *Derivation) Validate() error {
 		}
 
 		for i, o := range outputNames {
-			if i > 1 && o < outputNames[i-1] {
+			if i > 0 && o < outputNames[i-1] {
 				return fmt.Errorf("invalid input derivation output order: %s < %s", o, outputNames[i-1])
 			}
 


### PR DESCRIPTION
This fix makes sure to start checking with the first element (instead of the second).

cc @adisbladis 