### PR TITLE
GH actions: pin Nix version in fixture test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v17
+      install_url: https://releases.nixos.org/nix/nix-2.3.7/install
     - uses: actions/setup-go@v2
       with:
         go-version: '1.17'

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.48.0
+          version: v1.53.3
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,6 @@ linters:
     - goheader
     - goimports
     - gosec
-    - ifshort
     - importas
     - ireturn
     - lll

--- a/pkg/derivation/store/badger.go
+++ b/pkg/derivation/store/badger.go
@@ -137,7 +137,7 @@ func (bs *BadgerStore) Put(ctx context.Context, drv *derivation.Derivation) (str
 }
 
 // Get retrieves a Derivation by drv path from the Derivation Store.
-func (bs *BadgerStore) Get(ctx context.Context, derivationPath string) (*derivation.Derivation, error) {
+func (bs *BadgerStore) Get(_ context.Context, derivationPath string) (*derivation.Derivation, error) {
 	var drv *derivation.Derivation
 
 	err := bs.db.View(func(txn *badger.Txn) error {
@@ -169,7 +169,7 @@ func (bs *BadgerStore) Get(ctx context.Context, derivationPath string) (*derivat
 
 // Has returns whether the derivation (by drv path) exists.
 // This is done by using the Badger iterator with ValidForPrefix.
-func (bs *BadgerStore) Has(ctx context.Context, derivationPath string) (bool, error) {
+func (bs *BadgerStore) Has(_ context.Context, derivationPath string) (bool, error) {
 	found := false
 
 	err := bs.db.View(func(txn *badger.Txn) error {

--- a/pkg/derivation/store/filesystem.go
+++ b/pkg/derivation/store/filesystem.go
@@ -40,7 +40,7 @@ type FSStore struct {
 }
 
 // Put is not implemented right now.
-func (fs *FSStore) Put(ctx context.Context, drv *derivation.Derivation) (string, error) {
+func (fs *FSStore) Put(_ context.Context, _ *derivation.Derivation) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
@@ -51,7 +51,7 @@ func (fs *FSStore) getFilepath(derivationPath string) string {
 }
 
 // Get retrieves a Derivation by drv path from the Derivation Store.
-func (fs *FSStore) Get(ctx context.Context, derivationPath string) (*derivation.Derivation, error) {
+func (fs *FSStore) Get(_ context.Context, derivationPath string) (*derivation.Derivation, error) {
 	path := fs.getFilepath(derivationPath)
 
 	f, err := os.Open(path)
@@ -70,7 +70,7 @@ func (fs *FSStore) Get(ctx context.Context, derivationPath string) (*derivation.
 // Has returns whether the derivation (by drv path) exists.
 // We only need pass this down to the cache, as everything
 // we did Get() is stored in there.
-func (fs *FSStore) Has(ctx context.Context, derivationPath string) (bool, error) {
+func (fs *FSStore) Has(_ context.Context, derivationPath string) (bool, error) {
 	path := fs.getFilepath(derivationPath)
 
 	// Stat the file. We do an lstat here, to not follow symlinks.

--- a/pkg/derivation/store/http.go
+++ b/pkg/derivation/store/http.go
@@ -36,7 +36,7 @@ type HTTPStore struct {
 }
 
 // Put is not implemented right now.
-func (hs *HTTPStore) Put(ctx context.Context, drv *derivation.Derivation) (string, error) {
+func (hs *HTTPStore) Put(_ context.Context, _ *derivation.Derivation) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 

--- a/pkg/derivation/store/map.go
+++ b/pkg/derivation/store/map.go
@@ -61,7 +61,7 @@ func (ms *MapStore) Put(ctx context.Context, drv *derivation.Derivation) (string
 }
 
 // Get retrieves a Derivation by drv path from the Derivation Store.
-func (ms *MapStore) Get(ctx context.Context, derivationPath string) (*derivation.Derivation, error) {
+func (ms *MapStore) Get(_ context.Context, derivationPath string) (*derivation.Derivation, error) {
 	if drv, ok := ms.drvs[derivationPath]; ok {
 		return drv, nil
 	}
@@ -70,7 +70,7 @@ func (ms *MapStore) Get(ctx context.Context, derivationPath string) (*derivation
 }
 
 // Has returns whether the derivation (by drv path) exists.
-func (ms *MapStore) Has(ctx context.Context, derivationPath string) (bool, error) {
+func (ms *MapStore) Has(_ context.Context, derivationPath string) (bool, error) {
 	if _, ok := ms.drvs[derivationPath]; ok {
 		return true, nil
 	}


### PR DESCRIPTION
It seems the output has changed recently. Pin the version of Nix to prevent CI from failing unrelatedly.

Also, bump the golangci-lint version we're using and address some of the new warnings.