### PR TITLE
feat: add narinfo info command

### DIFF
--- a/cmd/gonix/main.go
+++ b/cmd/gonix/main.go
@@ -6,12 +6,14 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/nix-community/go-nix/cmd/gonix/drv"
 	"github.com/nix-community/go-nix/cmd/gonix/nar"
+	"github.com/nix-community/go-nix/cmd/gonix/narinfo"
 )
 
 //nolint:gochecknoglobals
 var cli struct {
-	Nar nar.Cmd `kong:"cmd,name='nar',help='Create or inspect NAR files'"`
-	Drv drv.Cmd `kong:"cmd,name='drv',help='Inspect NAR files'"`
+	Nar     nar.Cmd     `kong:"cmd,name='nar',help='Create or inspect NAR files'"`
+	Drv     drv.Cmd     `kong:"cmd,name='drv',help='Inspect NAR files'"`
+	NarInfo narinfo.Cmd `kong:"cmd,name='narinfo',help='Inspect narinfo files'"`
 }
 
 func main() {

--- a/cmd/gonix/narinfo/cmd.go
+++ b/cmd/gonix/narinfo/cmd.go
@@ -1,0 +1,5 @@
+package narinfo
+
+type Cmd struct {
+	Info InfoCmd `kong:"cmd,name='info',help='Show information about a narinfo file'"`
+}

--- a/cmd/gonix/narinfo/ls.go
+++ b/cmd/gonix/narinfo/ls.go
@@ -1,0 +1,28 @@
+package narinfo
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/nix-community/go-nix/pkg/narinfo"
+)
+
+type InfoCmd struct {
+	File string `kong:"arg,type:'file',help='Path to the narinfo file'"`
+}
+
+func (cmd *InfoCmd) Run() error {
+	f, err := os.Open(cmd.File)
+	if err != nil {
+		return err
+	}
+
+	nr, err := narinfo.Parse(f)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(nr.String())
+
+	return nil
+}


### PR DESCRIPTION
Useful for examining the store path of narinfo files created by the `nix copy` command.

ls *.narinfo | xargs -I {} gonix narinfo info {} | grep StorePath
