### PR TITLE
pkg/nixpath: move to pkg/storepath, make FromString receive non-absolute paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ A parser and generator for `.narinfo` files.
 An implementation of the slightly odd "base32" encoding that's used in Nix,
 providing some of the functions in `encoding/base32.Encoding`.
 
-## `pkg/nixpath`
+## `pkg/storepath`
 A parser and regexes for Nix Store Paths.
 
-## `pkg/nixpath/references`
+## `pkg/storepath/references`
 A Nix Store path reference scanner.
 
 ## `pkg/wire`

--- a/pkg/derivation/derivation.go
+++ b/pkg/derivation/derivation.go
@@ -3,7 +3,7 @@ package derivation
 import (
 	"fmt"
 
-	"github.com/nix-community/go-nix/pkg/nixpath"
+	"github.com/nix-community/go-nix/pkg/storepath"
 )
 
 // Derivation describes all data in a .drv, which canonically is expressed in ATerm format.
@@ -76,7 +76,7 @@ func (d *Derivation) Validate() error {
 	}
 
 	for inputDerivationPath := range d.InputDerivations {
-		err := nixpath.Validate(inputDerivationPath)
+		err := storepath.Validate(inputDerivationPath)
 		if err != nil {
 			return err
 		}
@@ -98,7 +98,7 @@ func (d *Derivation) Validate() error {
 	}
 
 	for i, is := range d.InputSources {
-		err := nixpath.Validate(is)
+		err := storepath.Validate(is)
 		if err != nil {
 			return fmt.Errorf("error validating input source '%s': %w", is, err)
 		}

--- a/pkg/derivation/derivation_test.go
+++ b/pkg/derivation/derivation_test.go
@@ -219,7 +219,13 @@ func TestWriter(t *testing.T) {
 
 				drvPath, err := drv.DrvPath()
 				assert.NoError(t, err, "calling DrvPath shouldn't error")
-				assert.Equal(t, nixpath.Absolute(c.DerivationFile), drvPath,
+
+				npExpected, err := nixpath.FromString(c.DerivationFile)
+				if err != nil {
+					panic(npExpected)
+				}
+
+				assert.Equal(t, npExpected.Absolute(), drvPath,
 					"drv path should be calculated correctly")
 			})
 		}
@@ -418,7 +424,12 @@ func TestDrvPath(t *testing.T) {
 				panic(err)
 			}
 
-			assert.Equal(t, nixpath.Absolute(c.DerivationFile), drvPath)
+			npExpected, err := nixpath.FromString(c.DerivationFile)
+			if err != nil {
+				panic(npExpected)
+			}
+
+			assert.Equal(t, npExpected.Absolute(), drvPath)
 		})
 	}
 }

--- a/pkg/derivation/derivation_test.go
+++ b/pkg/derivation/derivation_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/nix-community/go-nix/pkg/derivation"
-	"github.com/nix-community/go-nix/pkg/nixpath"
+	"github.com/nix-community/go-nix/pkg/storepath"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -220,12 +220,12 @@ func TestWriter(t *testing.T) {
 				drvPath, err := drv.DrvPath()
 				assert.NoError(t, err, "calling DrvPath shouldn't error")
 
-				npExpected, err := nixpath.FromString(c.DerivationFile)
+				spExpected, err := storepath.FromString(c.DerivationFile)
 				if err != nil {
-					panic(npExpected)
+					panic(spExpected)
 				}
 
-				assert.Equal(t, npExpected.Absolute(), drvPath,
+				assert.Equal(t, spExpected.Absolute(), drvPath,
 					"drv path should be calculated correctly")
 			})
 		}
@@ -424,12 +424,12 @@ func TestDrvPath(t *testing.T) {
 				panic(err)
 			}
 
-			npExpected, err := nixpath.FromString(c.DerivationFile)
+			spExpected, err := storepath.FromString(c.DerivationFile)
 			if err != nil {
-				panic(npExpected)
+				panic(spExpected)
 			}
 
-			assert.Equal(t, npExpected.Absolute(), drvPath)
+			assert.Equal(t, spExpected.Absolute(), drvPath)
 		})
 	}
 }

--- a/pkg/derivation/drv_path.go
+++ b/pkg/derivation/drv_path.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 
 	"github.com/nix-community/go-nix/pkg/hash"
-	"github.com/nix-community/go-nix/pkg/nixbase32"
 	"github.com/nix-community/go-nix/pkg/nixpath"
 )
 
@@ -95,5 +94,10 @@ func (d *Derivation) DrvPath() (string, error) {
 
 	atermDigest = h.Sum(nil)
 
-	return nixpath.Absolute(nixbase32.EncodeToString(hash.CompressHash(atermDigest, 20)) + "-" + name + ".drv"), nil
+	np := nixpath.NixPath{
+		Name:   name + ".drv",
+		Digest: hash.CompressHash(atermDigest, 20),
+	}
+
+	return np.Absolute(), nil
 }

--- a/pkg/derivation/drv_path.go
+++ b/pkg/derivation/drv_path.go
@@ -6,14 +6,14 @@ import (
 	"sort"
 
 	"github.com/nix-community/go-nix/pkg/hash"
-	"github.com/nix-community/go-nix/pkg/nixpath"
+	"github.com/nix-community/go-nix/pkg/storepath"
 )
 
 //nolint:gochecknoglobals
 var (
 	textColon     = []byte("text:")
 	sha256Colon   = []byte("sha256:")
-	storeDirColon = []byte(nixpath.StoreDir + ":")
+	storeDirColon = []byte(storepath.StoreDir + ":")
 	dotDrv        = []byte(".drv")
 )
 
@@ -94,7 +94,7 @@ func (d *Derivation) DrvPath() (string, error) {
 
 	atermDigest = h.Sum(nil)
 
-	np := nixpath.NixPath{
+	np := storepath.StorePath{
 		Name:   name + ".drv",
 		Digest: hash.CompressHash(atermDigest, 20),
 	}

--- a/pkg/derivation/hashes.go
+++ b/pkg/derivation/hashes.go
@@ -7,7 +7,6 @@ import (
 	chash "hash"
 
 	"github.com/nix-community/go-nix/pkg/hash"
-	"github.com/nix-community/go-nix/pkg/nixbase32"
 	"github.com/nix-community/go-nix/pkg/nixpath"
 )
 
@@ -117,10 +116,12 @@ func (d *Derivation) CalculateOutputPaths(inputDrvReplacements map[string]string
 			)
 		}
 
-		calculatedPath := nixpath.Absolute(nixbase32.EncodeToString(hash.CompressHash(storeHash, 20)) +
-			"-" + outputPathName)
+		calculatedPath := nixpath.NixPath{
+			Name:   outputPathName,
+			Digest: hash.CompressHash(storeHash, 20),
+		}
 
-		outputPaths[outputName] = calculatedPath
+		outputPaths[outputName] = calculatedPath.Absolute()
 
 		h.Reset()
 	}

--- a/pkg/derivation/hashes.go
+++ b/pkg/derivation/hashes.go
@@ -7,7 +7,7 @@ import (
 	chash "hash"
 
 	"github.com/nix-community/go-nix/pkg/hash"
-	"github.com/nix-community/go-nix/pkg/nixpath"
+	"github.com/nix-community/go-nix/pkg/storepath"
 )
 
 //nolint:gochecknoglobals
@@ -81,7 +81,7 @@ func (d *Derivation) CalculateOutputPaths(inputDrvReplacements map[string]string
 					"source",
 					"sha256",
 					o.Hash,
-					nixpath.StoreDir,
+					storepath.StoreDir,
 					derivationName,
 				)
 			} else {
@@ -95,7 +95,7 @@ func (d *Derivation) CalculateOutputPaths(inputDrvReplacements map[string]string
 					"out",
 					"sha256",
 					fixedHex,
-					nixpath.StoreDir,
+					storepath.StoreDir,
 					derivationName,
 				)
 			}
@@ -111,12 +111,12 @@ func (d *Derivation) CalculateOutputPaths(inputDrvReplacements map[string]string
 				outputName,
 				"sha256",
 				maskedATermHash,
-				nixpath.StoreDir,
+				storepath.StoreDir,
 				outputPathName,
 			)
 		}
 
-		calculatedPath := nixpath.NixPath{
+		calculatedPath := storepath.StorePath{
 			Name:   outputPathName,
 			Digest: hash.CompressHash(storeHash, 20),
 		}

--- a/pkg/derivation/output.go
+++ b/pkg/derivation/output.go
@@ -1,7 +1,7 @@
 package derivation
 
 import (
-	"github.com/nix-community/go-nix/pkg/nixpath"
+	"github.com/nix-community/go-nix/pkg/storepath"
 )
 
 type Output struct {
@@ -11,5 +11,5 @@ type Output struct {
 }
 
 func (o *Output) Validate() error {
-	return nixpath.Validate(o.Path)
+	return storepath.Validate(o.Path)
 }

--- a/pkg/derivation/store/filesystem.go
+++ b/pkg/derivation/store/filesystem.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/nix-community/go-nix/pkg/derivation"
-	"github.com/nix-community/go-nix/pkg/nixpath"
+	"github.com/nix-community/go-nix/pkg/storepath"
 )
 
 // FSStore implements derivation.Store.
@@ -17,10 +17,10 @@ var _ derivation.Store = &FSStore{}
 
 // NewFSStore returns a store exposing all `.drv` files in the directory
 // specified by storageDir.
-// If storageDir is set to an empty string, nixpath.StoreDir is used as a directory.
+// If storageDir is set to an empty string, storepath.StoreDir is used as a directory.
 func NewFSStore(storageDir string) (*FSStore, error) {
 	if storageDir == "" {
-		storageDir = nixpath.StoreDir
+		storageDir = storepath.StoreDir
 	}
 
 	return &FSStore{

--- a/pkg/derivation/store/filesystem_test.go
+++ b/pkg/derivation/store/filesystem_test.go
@@ -33,8 +33,12 @@ func TestFSStore(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.Title, func(t *testing.T) {
-			drvPath := nixpath.Absolute(c.DerivationFile)
-			_, err := drvStore.Get(context.Background(), drvPath)
+			drvPath, err := nixpath.FromString(c.DerivationFile)
+			if err != nil {
+				panic(err)
+			}
+
+			_, err = drvStore.Get(context.Background(), drvPath.Absolute())
 			assert.NoError(t, err, "Get(%v) shouldn't error", c.DerivationFile)
 		})
 	}

--- a/pkg/derivation/store/filesystem_test.go
+++ b/pkg/derivation/store/filesystem_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/nix-community/go-nix/pkg/derivation/store"
-	"github.com/nix-community/go-nix/pkg/nixpath"
+	"github.com/nix-community/go-nix/pkg/storepath"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,7 +33,7 @@ func TestFSStore(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.Title, func(t *testing.T) {
-			drvPath, err := nixpath.FromString(c.DerivationFile)
+			drvPath, err := storepath.FromString(c.DerivationFile)
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/derivation/store/http.go
+++ b/pkg/derivation/store/http.go
@@ -43,7 +43,7 @@ func (hs *HTTPStore) Put(_ context.Context, _ *derivation.Derivation) (string, e
 // getURL returns the full url to a derivation path,
 // with respect to the configured BaseURL.
 // It constructs the URL by appending the derivation path,
-// cleaned by nixpath.StoreDir.
+// cleaned by storepath.StoreDir.
 func (hs *HTTPStore) getURL(derivationPath string) url.URL {
 	// copy the base url
 	url := *hs.BaseURL

--- a/pkg/derivation/store/store_test.go
+++ b/pkg/derivation/store/store_test.go
@@ -115,7 +115,12 @@ func TestStores(t *testing.T) {
 						drvPath, err := store.Put(context.Background(), drv)
 
 						assert.NoError(t, err, "Put()'ing the derivation shouldn't cause an error")
-						assert.Equal(t, nixpath.Absolute(c.DerivationFile), drvPath)
+
+						npExpected, err := nixpath.FromString(c.DerivationFile)
+						if err != nil {
+							panic(err)
+						}
+						assert.Equal(t, npExpected.Absolute(), drvPath)
 					})
 				}
 			})

--- a/pkg/derivation/store/store_test.go
+++ b/pkg/derivation/store/store_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/nix-community/go-nix/pkg/derivation"
 	"github.com/nix-community/go-nix/pkg/derivation/store"
-	"github.com/nix-community/go-nix/pkg/nixpath"
+	"github.com/nix-community/go-nix/pkg/storepath"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -116,11 +116,11 @@ func TestStores(t *testing.T) {
 
 						assert.NoError(t, err, "Put()'ing the derivation shouldn't cause an error")
 
-						npExpected, err := nixpath.FromString(c.DerivationFile)
+						spExpected, err := storepath.FromString(c.DerivationFile)
 						if err != nil {
 							panic(err)
 						}
-						assert.Equal(t, npExpected.Absolute(), drvPath)
+						assert.Equal(t, spExpected.Absolute(), drvPath)
 					})
 				}
 			})

--- a/pkg/narinfo/check.go
+++ b/pkg/narinfo/check.go
@@ -14,23 +14,20 @@ import (
 //   - when no compression is present, ensuring File{Hash,Size} and
 //     Nar{Hash,Size} are equal
 func (n *NarInfo) Check() error {
-	_, err := nixpath.FromString(n.StorePath)
+	_, err := nixpath.FromAbsolutePath(n.StorePath)
 	if err != nil {
-		return fmt.Errorf("invalid NixPath at StorePath: %v", n.StorePath)
+		return fmt.Errorf("invalid NixPath at StorePath: %v: %s", n.StorePath, err)
 	}
 
 	for i, r := range n.References {
-		referenceAbsolute := nixpath.Absolute(r)
-		_, err = nixpath.FromString(referenceAbsolute)
+		_, err = nixpath.FromString(r)
 
 		if err != nil {
 			return fmt.Errorf("invalid NixPath at Reference[%d]: %v", i, r)
 		}
 	}
 
-	deriverAbsolute := nixpath.Absolute(n.Deriver)
-
-	_, err = nixpath.FromString(deriverAbsolute)
+	_, err = nixpath.FromString(n.Deriver)
 	if err != nil {
 		return fmt.Errorf("invalid NixPath at Deriver: %v", n.Deriver)
 	}

--- a/pkg/narinfo/check.go
+++ b/pkg/narinfo/check.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/nix-community/go-nix/pkg/nixpath"
+	"github.com/nix-community/go-nix/pkg/storepath"
 )
 
 // Check does some sanity checking on a NarInfo struct, such as:
@@ -14,22 +14,22 @@ import (
 //   - when no compression is present, ensuring File{Hash,Size} and
 //     Nar{Hash,Size} are equal
 func (n *NarInfo) Check() error {
-	_, err := nixpath.FromAbsolutePath(n.StorePath)
+	_, err := storepath.FromAbsolutePath(n.StorePath)
 	if err != nil {
-		return fmt.Errorf("invalid NixPath at StorePath: %v: %s", n.StorePath, err)
+		return fmt.Errorf("invalid StorePath: %v: %s", n.StorePath, err)
 	}
 
 	for i, r := range n.References {
-		_, err = nixpath.FromString(r)
+		_, err = storepath.FromString(r)
 
 		if err != nil {
-			return fmt.Errorf("invalid NixPath at Reference[%d]: %v", i, r)
+			return fmt.Errorf("invalid Reference[%d]: %v", i, r)
 		}
 	}
 
-	_, err = nixpath.FromString(n.Deriver)
+	_, err = storepath.FromString(n.Deriver)
 	if err != nil {
-		return fmt.Errorf("invalid NixPath at Deriver: %v", n.Deriver)
+		return fmt.Errorf("invalid Deriver: %v", n.Deriver)
 	}
 
 	if n.Compression != "none" {

--- a/pkg/narinfo/fingerprint.go
+++ b/pkg/narinfo/fingerprint.go
@@ -3,7 +3,7 @@ package narinfo
 import (
 	"strconv"
 
-	"github.com/nix-community/go-nix/pkg/nixpath"
+	"github.com/nix-community/go-nix/pkg/storepath"
 )
 
 // Fingerprint is the digest that will be used with a private key to generate
@@ -19,7 +19,7 @@ func (n NarInfo) Fingerprint() string {
 	}
 
 	for _, ref := range n.References {
-		f += nixpath.StoreDir + "/" + ref + ","
+		f += storepath.StoreDir + "/" + ref + ","
 	}
 
 	return f[:len(f)-1]

--- a/pkg/nixpath/nixpath_test.go
+++ b/pkg/nixpath/nixpath_test.go
@@ -1,8 +1,6 @@
 package nixpath_test
 
 import (
-	"path"
-	"strings"
 	"testing"
 
 	"github.com/nix-community/go-nix/pkg/nixpath"
@@ -11,23 +9,44 @@ import (
 
 func TestNixPath(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
-		exampleNixPathStr := "/nix/store/00bgd045z0d4icpbc2yyz4gx48ak44la-net-tools-1.60_p20170221182432"
-		nixpath, err := nixpath.FromString(exampleNixPathStr)
+		exampleAbsolutePath := "/nix/store/00bgd045z0d4icpbc2yyz4gx48ak44la-net-tools-1.60_p20170221182432"
+		exampleNonAbsolutePath := "00bgd045z0d4icpbc2yyz4gx48ak44la-net-tools-1.60_p20170221182432"
 
-		if assert.NoError(t, err) {
-			assert.Equal(t, "net-tools-1.60_p20170221182432", nixpath.Name)
-			assert.Equal(t, []byte{
-				0x8a, 0x12, 0x32, 0x15, 0x22, 0xfd, 0x91, 0xef, 0xbd, 0x60, 0xeb, 0xb2, 0x48, 0x1a, 0xf8, 0x85,
-				0x80, 0xf6, 0x16, 0x00,
-			}, nixpath.Digest)
-		}
+		t.Run("FromString", func(t *testing.T) {
+			nixpath, err := nixpath.FromString(exampleNonAbsolutePath)
 
-		// Test to string
-		assert.Equal(t, exampleNixPathStr, nixpath.String())
+			if assert.NoError(t, err) {
+				assert.Equal(t, "net-tools-1.60_p20170221182432", nixpath.Name)
+				assert.Equal(t, []byte{
+					0x8a, 0x12, 0x32, 0x15, 0x22, 0xfd, 0x91, 0xef, 0xbd, 0x60, 0xeb, 0xb2, 0x48, 0x1a, 0xf8, 0x85,
+					0x80, 0xf6, 0x16, 0x00,
+				}, nixpath.Digest)
+			}
+
+			// Test String() and Absolute()
+			assert.Equal(t, exampleNonAbsolutePath, nixpath.String())
+			assert.Equal(t, exampleAbsolutePath, nixpath.Absolute())
+		})
+
+		t.Run("FromAbsolutePath", func(t *testing.T) {
+			nixpath, err := nixpath.FromAbsolutePath(exampleAbsolutePath)
+
+			if assert.NoError(t, err) {
+				assert.Equal(t, "net-tools-1.60_p20170221182432", nixpath.Name)
+				assert.Equal(t, []byte{
+					0x8a, 0x12, 0x32, 0x15, 0x22, 0xfd, 0x91, 0xef, 0xbd, 0x60, 0xeb, 0xb2, 0x48, 0x1a, 0xf8, 0x85,
+					0x80, 0xf6, 0x16, 0x00,
+				}, nixpath.Digest)
+			}
+
+			// Test String() and Absolute()
+			assert.Equal(t, exampleNonAbsolutePath, nixpath.String())
+			assert.Equal(t, exampleAbsolutePath, nixpath.Absolute())
+		})
 	})
 
 	t.Run("invalid hash length", func(t *testing.T) {
-		s := "/nix/store/00bgd045z0d4icpbc2yy-net-tools-1.60_p20170221182432"
+		s := "00bgd045z0d4icpbc2yy-net-tools-1.60_p20170221182432"
 
 		_, err := nixpath.FromString(s)
 		assert.Error(t, err)
@@ -37,7 +56,7 @@ func TestNixPath(t *testing.T) {
 	})
 
 	t.Run("invalid encoding in hash", func(t *testing.T) {
-		s := "/nix/store/00bgd045z0d4icpbc2yyz4gx48aku4la-net-tools-1.60_p20170221182432"
+		s := "00bgd045z0d4icpbc2yyz4gx48aku4la-net-tools-1.60_p20170221182432"
 
 		_, err := nixpath.FromString(s)
 		assert.Error(t, err)
@@ -47,7 +66,7 @@ func TestNixPath(t *testing.T) {
 	})
 
 	t.Run("more than just the bare nix store path", func(t *testing.T) {
-		s := "/nix/store/00bgd045z0d4icpbc2yyz4gx48aku4la-net-tools-1.60_p20170221182432/bin/arp"
+		s := "00bgd045z0d4icpbc2yyz4gx48aku4la-net-tools-1.60_p20170221182432/bin/arp"
 
 		_, err := nixpath.FromString(s)
 		assert.Error(t, err)
@@ -57,32 +76,9 @@ func TestNixPath(t *testing.T) {
 	})
 }
 
-func TestNixPathAbsolute(t *testing.T) {
-	t.Run("simple (foo)", func(t *testing.T) {
-		s := nixpath.Absolute("foo")
-		assert.Equal(t, nixpath.StoreDir+"/"+"foo", s)
-	})
-	t.Run("subdir (foo/bar)", func(t *testing.T) {
-		s := nixpath.Absolute("foo/bar")
-		assert.Equal(t, nixpath.StoreDir+"/"+"foo/bar", s)
-	})
-	t.Run("with ../ getting cleaned (foo/bar/.. -> foo)", func(t *testing.T) {
-		s := nixpath.Absolute("foo/bar/..")
-		assert.Equal(t, nixpath.StoreDir+"/"+"foo", s)
-	})
-	// test you can use this to exit nixpath.StoreDir
-	// Note path.Join does a path.Clean already, this is only
-	// written for additional clarity.
-	t.Run("leave storeDir", func(t *testing.T) {
-		s := nixpath.Absolute("..")
-		assert.Equal(t, path.Clean(path.Join(nixpath.StoreDir, "..")), s)
-		assert.False(t, strings.HasPrefix(s, nixpath.StoreDir),
-			"path shouldn't have the full storedir as prefix anymore (/nix)")
-	})
-}
-
 func BenchmarkNixPath(b *testing.B) {
-	path := "/nix/store/00bgd045z0d4icpbc2yyz4gx48ak44la-net-tools-1.60_p20170221182432"
+	path := "00bgd045z0d4icpbc2yyz4gx48ak44la-net-tools-1.60_p20170221182432"
+	pathAbsolute := nixpath.StoreDir + "/00bgd045z0d4icpbc2yyz4gx48ak44la-net-tools-1.60_p20170221182432"
 
 	b.Run("FromString", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
@@ -93,9 +89,18 @@ func BenchmarkNixPath(b *testing.B) {
 		}
 	})
 
+	b.Run("FromAbsolutePath", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, err := nixpath.FromAbsolutePath(pathAbsolute)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
 	b.Run("Validate", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			err := nixpath.Validate(path)
+			err := nixpath.Validate(pathAbsolute)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/pkg/storepath/references/refs.go
+++ b/pkg/storepath/references/refs.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 
 	"github.com/nix-community/go-nix/pkg/nixbase32"
-	"github.com/nix-community/go-nix/pkg/nixpath"
+	"github.com/nix-community/go-nix/pkg/storepath"
 )
 
 const (
-	storePrefixLength = len(nixpath.StoreDir) + 1
+	storePrefixLength = len(storepath.StoreDir) + 1
 	refLength         = len(nixbase32.Alphabet) // Store path hash prefix length
 )
 
@@ -35,12 +35,12 @@ func NewReferenceScanner(storePathCandidates []string) (*ReferenceScanner, error
 	hashes := make(map[string]string)
 
 	for _, storePath := range storePathCandidates {
-		if !strings.HasPrefix(storePath, nixpath.StoreDir) {
+		if !strings.HasPrefix(storePath, storepath.StoreDir) {
 			return nil, fmt.Errorf("missing store path prefix: %s", storePath)
 		}
 
 		// Check length is a valid store path length including dashes
-		if len(storePath) < len(nixpath.StoreDir)+refLength+3 {
+		if len(storePath) < len(storepath.StoreDir)+refLength+3 {
 			return nil, fmt.Errorf("invalid store path length: %d for store path '%s'", len(storePath), storePath)
 		}
 

--- a/pkg/storepath/references/refs_test.go
+++ b/pkg/storepath/references/refs_test.go
@@ -3,7 +3,7 @@ package references_test
 import (
 	"testing"
 
-	"github.com/nix-community/go-nix/pkg/nixpath/references"
+	"github.com/nix-community/go-nix/pkg/storepath/references"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/storepath/storepath_test.go
+++ b/pkg/storepath/storepath_test.go
@@ -1,88 +1,88 @@
-package nixpath_test
+package storepath_test
 
 import (
 	"testing"
 
-	"github.com/nix-community/go-nix/pkg/nixpath"
+	"github.com/nix-community/go-nix/pkg/storepath"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNixPath(t *testing.T) {
+func TestStorePath(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		exampleAbsolutePath := "/nix/store/00bgd045z0d4icpbc2yyz4gx48ak44la-net-tools-1.60_p20170221182432"
 		exampleNonAbsolutePath := "00bgd045z0d4icpbc2yyz4gx48ak44la-net-tools-1.60_p20170221182432"
 
 		t.Run("FromString", func(t *testing.T) {
-			nixpath, err := nixpath.FromString(exampleNonAbsolutePath)
+			storePath, err := storepath.FromString(exampleNonAbsolutePath)
 
 			if assert.NoError(t, err) {
-				assert.Equal(t, "net-tools-1.60_p20170221182432", nixpath.Name)
+				assert.Equal(t, "net-tools-1.60_p20170221182432", storePath.Name)
 				assert.Equal(t, []byte{
 					0x8a, 0x12, 0x32, 0x15, 0x22, 0xfd, 0x91, 0xef, 0xbd, 0x60, 0xeb, 0xb2, 0x48, 0x1a, 0xf8, 0x85,
 					0x80, 0xf6, 0x16, 0x00,
-				}, nixpath.Digest)
+				}, storePath.Digest)
 			}
 
 			// Test String() and Absolute()
-			assert.Equal(t, exampleNonAbsolutePath, nixpath.String())
-			assert.Equal(t, exampleAbsolutePath, nixpath.Absolute())
+			assert.Equal(t, exampleNonAbsolutePath, storePath.String())
+			assert.Equal(t, exampleAbsolutePath, storePath.Absolute())
 		})
 
 		t.Run("FromAbsolutePath", func(t *testing.T) {
-			nixpath, err := nixpath.FromAbsolutePath(exampleAbsolutePath)
+			storePath, err := storepath.FromAbsolutePath(exampleAbsolutePath)
 
 			if assert.NoError(t, err) {
-				assert.Equal(t, "net-tools-1.60_p20170221182432", nixpath.Name)
+				assert.Equal(t, "net-tools-1.60_p20170221182432", storePath.Name)
 				assert.Equal(t, []byte{
 					0x8a, 0x12, 0x32, 0x15, 0x22, 0xfd, 0x91, 0xef, 0xbd, 0x60, 0xeb, 0xb2, 0x48, 0x1a, 0xf8, 0x85,
 					0x80, 0xf6, 0x16, 0x00,
-				}, nixpath.Digest)
+				}, storePath.Digest)
 			}
 
 			// Test String() and Absolute()
-			assert.Equal(t, exampleNonAbsolutePath, nixpath.String())
-			assert.Equal(t, exampleAbsolutePath, nixpath.Absolute())
+			assert.Equal(t, exampleNonAbsolutePath, storePath.String())
+			assert.Equal(t, exampleAbsolutePath, storePath.Absolute())
 		})
 	})
 
 	t.Run("invalid hash length", func(t *testing.T) {
 		s := "00bgd045z0d4icpbc2yy-net-tools-1.60_p20170221182432"
 
-		_, err := nixpath.FromString(s)
+		_, err := storepath.FromString(s)
 		assert.Error(t, err)
 
-		err = nixpath.Validate(s)
+		err = storepath.Validate(s)
 		assert.Error(t, err)
 	})
 
 	t.Run("invalid encoding in hash", func(t *testing.T) {
 		s := "00bgd045z0d4icpbc2yyz4gx48aku4la-net-tools-1.60_p20170221182432"
 
-		_, err := nixpath.FromString(s)
+		_, err := storepath.FromString(s)
 		assert.Error(t, err)
 
-		err = nixpath.Validate(s)
+		err = storepath.Validate(s)
 		assert.Error(t, err)
 	})
 
 	t.Run("more than just the bare nix store path", func(t *testing.T) {
 		s := "00bgd045z0d4icpbc2yyz4gx48aku4la-net-tools-1.60_p20170221182432/bin/arp"
 
-		_, err := nixpath.FromString(s)
+		_, err := storepath.FromString(s)
 		assert.Error(t, err)
 
-		err = nixpath.Validate(s)
+		err = storepath.Validate(s)
 		assert.Error(t, err)
 	})
 }
 
-func BenchmarkNixPath(b *testing.B) {
+func BenchmarkStorePath(b *testing.B) {
 	path := "00bgd045z0d4icpbc2yyz4gx48ak44la-net-tools-1.60_p20170221182432"
-	pathAbsolute := nixpath.StoreDir + "/00bgd045z0d4icpbc2yyz4gx48ak44la-net-tools-1.60_p20170221182432"
+	pathAbsolute := storepath.StoreDir + "/00bgd045z0d4icpbc2yyz4gx48ak44la-net-tools-1.60_p20170221182432"
 
 	b.Run("FromString", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, err := nixpath.FromString(path)
+			_, err := storepath.FromString(path)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -91,7 +91,7 @@ func BenchmarkNixPath(b *testing.B) {
 
 	b.Run("FromAbsolutePath", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_, err := nixpath.FromAbsolutePath(pathAbsolute)
+			_, err := storepath.FromAbsolutePath(pathAbsolute)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -100,7 +100,7 @@ func BenchmarkNixPath(b *testing.B) {
 
 	b.Run("Validate", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			err := nixpath.Validate(pathAbsolute)
+			err := storepath.Validate(pathAbsolute)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -108,7 +108,7 @@ func BenchmarkNixPath(b *testing.B) {
 	})
 
 	{
-		p, err := nixpath.FromString(path)
+		p, err := storepath.FromString(path)
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
The whole module layout was a bit messy - store paths had to be passed in primarily with the store dir prefix, even though it's not possible to have a different prefix, at least with the way it's currently structured.

There were Absolute() helper functions which helped with concatenation of strings, but no actual validation, which also were not really used outside of tests. The comments were also wrong, as no cleaning of store paths actually did happen.
Some library code (like pkg/derivation) even started implementing their own String() methods.

Clean this up a bit - have NixPath's FromString() receive a non-absolute path, and have an additional FromAbsolutePath() method that can be used if you have an absolute path.

Move from nixpath.Absolute() to a Absolute() function defined on a specific NixPath struct.

This moves things closer to how they look in the corresponding `nix_compat::store_path::StorePath` rust codebase.