### PR TITLE
pkg/hash: add FromHashTypeAndDigest function

### DIFF
--- a/pkg/hash/encode.go
+++ b/pkg/hash/encode.go
@@ -32,11 +32,6 @@ func (h *Hash) Multihash() []byte {
 func (h *Hash) NixString() string {
 	digest := h.Digest()
 
-	// This can only occur if the struct is filled manually
-	if h.hash.Size() != len(digest) {
-		panic("invalid digest length")
-	}
-
 	if hashStr, ok := hashtypeToNixHashString[h.HashType]; ok {
 		return fmt.Sprintf("%v:%v", hashStr, nixbase32.EncodeToString(digest))
 	}
@@ -46,11 +41,6 @@ func (h *Hash) NixString() string {
 
 func (h *Hash) SRIString() string {
 	digest := h.Digest()
-
-	// This can only occur if the struct is filled manually
-	if h.hash.Size() != len(digest) {
-		panic("invalid digest length")
-	}
 
 	if hashStr, ok := hashtypeToNixHashString[h.HashType]; ok {
 		return fmt.Sprintf("%v-%v", hashStr, base64.StdEncoding.EncodeToString(digest))

--- a/pkg/hash/from.go
+++ b/pkg/hash/from.go
@@ -1,0 +1,36 @@
+package hash
+
+import (
+	"fmt"
+
+	mh "github.com/multiformats/go-multihash/core"
+)
+
+// FromHashTypeAndDigest constructs a Hash from hashType and digest.
+// hashType needs to be a supported multihash type,
+// and the digest len needs to be correct, otherwise an error is returned.
+func FromHashTypeAndDigest(hashType int, digest []byte) (*Hash, error) {
+	var expectedDigestSize int
+
+	switch hashType {
+	case mh.SHA1:
+		expectedDigestSize = 20
+	case mh.SHA2_256:
+		expectedDigestSize = 32
+	case mh.SHA2_512:
+		expectedDigestSize = 64
+	default:
+		return nil, fmt.Errorf("unknown hash type: %d", hashType)
+	}
+
+	if len(digest) != expectedDigestSize {
+		return nil, fmt.Errorf("wrong digest len, expected %d, got %d", expectedDigestSize, len(digest))
+	}
+
+	return &Hash{
+		HashType:     hashType,
+		hash:         nil,
+		bytesWritten: 0,
+		digest:       digest,
+	}, nil
+}

--- a/pkg/hash/parser.go
+++ b/pkg/hash/parser.go
@@ -33,29 +33,12 @@ func ParseNixBase32(s string) (*Hash, error) {
 	}
 
 	// The digest afterwards is nixbase32-encoded.
-	// Calculate the length of that string, in nixbase32 encoding
-	h, err := mh.GetHasher(uint64(hashType))
-	if err != nil {
-		return nil, err
-	}
-
-	digestLenBytes := h.Size()
-	encodedDigestLen := nixbase32.EncodedLen(digestLenBytes)
-
 	encodedDigestStr := s[i+1:]
-	if len(encodedDigestStr) != encodedDigestLen {
-		return nil, fmt.Errorf("invalid length for encoded digest line %v", s)
-	}
 
 	digest, err := nixbase32.DecodeString(encodedDigestStr)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Hash{
-		HashType: hashType,
-		// even though the hash function is never written too, we still keep it around, for h.hash.Size() checks etc.
-		hash:   h,
-		digest: digest,
-	}, nil
+	return FromHashTypeAndDigest(hashType, digest)
 }


### PR DESCRIPTION
This allows creating a Hash from a hashType and digest.

We don't populate unused h.hash anymore, as ParseNixBase32 now uses FromHashTypeAndDigest too, and the size checks are done there.

cc @lheckemann