### PR TITLE
narinfo: Fix the splitOnce function

### DIFF
--- a/pkg/narinfo/parser.go
+++ b/pkg/narinfo/parser.go
@@ -112,7 +112,7 @@ func splitOnce(s string, sep string) (string, string, error) {
 		return "", "", fmt.Errorf("unable to find separator '%s' in %v", sep, s)
 	}
 
-	if strings.Contains(s[:idx], sep) {
+	if strings.Contains(s[idx+1:], sep) {
 		return "", "", fmt.Errorf("found separator '%s' twice or more in %v", sep, s)
 	}
 

--- a/pkg/narinfo/splitonce_test.go
+++ b/pkg/narinfo/splitonce_test.go
@@ -1,0 +1,56 @@
+//nolint:testpackage
+package narinfo
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSplitOnce(t *testing.T) {
+	tests := []struct {
+		s    string
+		sep  string
+		str1 string
+		str2 string
+		err  string
+	}{
+		{"hello:world", ":", "hello", "world", ""},
+		{"helloworld", ":", "", "", "unable to find separator ':' in helloworld"},
+		{"hello:wo:rld", ":", "", "", "found separator ':' twice or more in hello:wo:rld"},
+	}
+
+	t.Parallel()
+
+	for _, ltest := range tests {
+		// TODO: This is not necessary on Go >=1.23. Remove this assignment and use
+		// test instead of ltest above.
+		test := ltest
+
+		tName := fmt.Sprintf("splitOnce(%q, %q) -> (%q, %q, %s)",
+			test.s, test.sep, test.str1, test.str2, test.err)
+
+		t.Run(tName, func(t *testing.T) {
+			t.Parallel()
+
+			str1, str2, err := splitOnce(test.s, test.sep)
+
+			if test.err == "" && err != nil {
+				t.Fatalf("expected no error but got %s", err)
+			} else if test.err != "" && err == nil {
+				t.Fatalf("expected an error but got none")
+			} else if test.err != "" && err != nil {
+				if want, got := test.err, err.Error(); want != got {
+					t.Errorf("want %q got %q", want, got)
+				}
+			}
+
+			if want, got := test.str1, str1; want != got {
+				t.Errorf("want %q got %q", want, got)
+			}
+
+			if want, got := test.str2, str2; want != got {
+				t.Errorf("want %q got %q", want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The splitOnce function has a bug in the detection of multiple `sep` in the same `s`, in fact, the error is never raised because it checks for the presence of `sep` in the part of `s` that's before the first `sep` and that's never true.

I added a test file to replicate this bug, and to fix it. I had to disable the `testpackage` lint for the test file otherwise it's not possible to test this function since it's not exported.