### PR TITLE
narinfo: Deriver is optional, Check must not fail if empty

### DIFF
--- a/pkg/narinfo/check.go
+++ b/pkg/narinfo/check.go
@@ -26,9 +26,11 @@ func (n *NarInfo) Check() error {
 		}
 	}
 
-	_, err = storepath.FromString(n.Deriver)
-	if err != nil {
-		return fmt.Errorf("invalid Deriver: %v", n.Deriver)
+	if n.Deriver != "" {
+		_, err = storepath.FromString(n.Deriver)
+		if err != nil {
+			return fmt.Errorf("invalid Deriver: %v", n.Deriver)
+		}
 	}
 
 	if n.Compression != "none" {

--- a/pkg/narinfo/narinfo_test.go
+++ b/pkg/narinfo/narinfo_test.go
@@ -78,6 +78,19 @@ Sig: cache.nixos.org-1:sn5s/RrqEI+YG6/PjwdbPjcAC7rcta7sJU4mFOawGvJBLsWkyLtBrT2Eu
 Sig: hydra.other.net-1:JXQ3Z/PXf0EZSFkFioa4FbyYpbbTbHlFBtZf4VqU0tuMTWzhMD7p9Q7acJjLn3jofOtilAAwRILKIfVuyrbjAA==
 `
 
+	strNarinfoSampleWithoutDeriverFields = `
+StorePath: /nix/store/00bgd045z0d4icpbc2yyz4gx48ak44la-net-tools-1.60_p20170221182432
+URL: nar/1094wph9z4nwlgvsd53abfz8i117ykiv5dwnq9nnhz846s7xqd7d.nar.xz
+Compression: xz
+FileHash: sha256:1094wph9z4nwlgvsd53abfz8i117ykiv5dwnq9nnhz846s7xqd7d
+FileSize: 114980
+NarHash: sha256:0lxjvvpr59c2mdram7ympy5ay741f180kv3349hvfc3f8nrmbqf6
+NarSize: 464152
+References: 7gx4kiv5m0i7d7qkixq2cwzbr10lvxwc-glibc-2.27
+Sig: cache.nixos.org-1:sn5s/RrqEI+YG6/PjwdbPjcAC7rcta7sJU4mFOawGvJBLsWkyLtBrT2EuFt/LJjWkTZ+ZWOI9NTtjo/woMdvAg==
+Sig: hydra.other.net-1:JXQ3Z/PXf0EZSFkFioa4FbyYpbbTbHlFBtZf4VqU0tuMTWzhMD7p9Q7acJjLn3jofOtilAAwRILKIfVuyrbjAA==
+`
+
 	_NarHash = mustParseNixBase32("sha256:0lxjvvpr59c2mdram7ympy5ay741f180kv3349hvfc3f8nrmbqf6")
 
 	_SignaturesNarinfoSample = []signature.Signature{
@@ -108,6 +121,18 @@ Sig: hydra.other.net-1:JXQ3Z/PXf0EZSFkFioa4FbyYpbbTbHlFBtZf4VqU0tuMTWzhMD7p9Q7ac
 		NarSize:     464152,
 		References:  []string{"7gx4kiv5m0i7d7qkixq2cwzbr10lvxwc-glibc-2.27"},
 		Deriver:     "10dx1q4ivjb115y3h90mipaaz533nr0d-net-tools-1.60_p20170221182432.drv",
+		Signatures:  _SignaturesNarinfoSample,
+	}
+
+	narinfoSampleWithoutDeriverFields = &narinfo.NarInfo{
+		StorePath:   "/nix/store/00bgd045z0d4icpbc2yyz4gx48ak44la-net-tools-1.60_p20170221182432",
+		URL:         "nar/1094wph9z4nwlgvsd53abfz8i117ykiv5dwnq9nnhz846s7xqd7d.nar.xz",
+		Compression: "xz",
+		FileHash:    mustParseNixBase32("sha256:1094wph9z4nwlgvsd53abfz8i117ykiv5dwnq9nnhz846s7xqd7d"),
+		FileSize:    114980,
+		NarHash:     _NarHash,
+		NarSize:     464152,
+		References:  []string{"7gx4kiv5m0i7d7qkixq2cwzbr10lvxwc-glibc-2.27"},
 		Signatures:  _SignaturesNarinfoSample,
 	}
 
@@ -201,6 +226,18 @@ func TestNarInfoWithoutFileFields(t *testing.T) {
 
 	// Test to string
 	assert.Equal(t, strNarinfoSampleWithoutFileFields, "\n"+ni.String())
+}
+
+func TestNarInfoWithoutDeriverFields(t *testing.T) {
+	ni, err := narinfo.Parse(strings.NewReader(strNarinfoSampleWithoutDeriverFields))
+	assert.NoError(t, err)
+
+	// Test the parsing happy path
+	assert.Equal(t, narinfoSampleWithoutDeriverFields, ni)
+	assert.NoError(t, ni.Check())
+
+	// Test to string
+	assert.Equal(t, strNarinfoSampleWithoutDeriverFields, "\n"+ni.String())
 }
 
 func TestBigNarinfo(t *testing.T) {


### PR DESCRIPTION
The deriver field is optional so the `Check()` function should not return an error if it's empty.

References:
- [nix-serve source code](https://github.com/edolstra/nix-serve/blob/2641d7f6372572f82f8701f38c8cd5aaed0188b4/nix-serve.psgi#L37).
- [narinfo rust crate](https://docs.rs/narinfo/latest/narinfo/struct.NarInfo.html#structfield.deriver)

ref https://github.com/kalbasit/ncps/issues/51