### PR TITLE
fix(nixbase32): do not panic for invalid encoding

### DIFF
--- a/pkg/nixbase32/nixbase32.go
+++ b/pkg/nixbase32/nixbase32.go
@@ -9,9 +9,13 @@ doesn't use any padding), which makes adopting encoding/base32 hard.
 package nixbase32
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
+
+// ErrInvalidHash is returned if the hash is not valid.
+var ErrInvalidHash = errors.New("hash is not valid")
 
 // Alphabet contains the list of valid characters for the Nix base32 Alphabet.
 const Alphabet = "0123456789abcdfghijklmnpqrsvwxyz"
@@ -41,6 +45,10 @@ func Decode(dst, src []byte) (n int, err error) {
 
 		if digit == -1 {
 			return i, fmt.Errorf("decode base32: character %q not in Nix alphabet", c)
+		}
+
+		if i >= len(dst) {
+			return i, ErrInvalidHash
 		}
 
 		// OR the main pattern

--- a/pkg/nixbase32/nixbase32_test.go
+++ b/pkg/nixbase32/nixbase32_test.go
@@ -9,6 +9,7 @@ import (
 
 	//nolint:revive
 	. "github.com/nix-community/go-nix/pkg/nixbase32"
+	"github.com/stretchr/testify/assert"
 )
 
 //nolint:gochecknoglobals
@@ -244,4 +245,40 @@ func BenchmarkValidateString(b *testing.B) {
 			}
 		})
 	}
+}
+
+func FuzzDecodeString(f *testing.F) {
+	for _, test := range tests {
+		f.Add(test.enc)
+	}
+
+	f.Fuzz(func(t *testing.T, enc1 string) {
+		dec, err := DecodeString(enc1)
+		if err != nil {
+			t.Skip()
+		}
+
+		enc2 := EncodeToString(dec)
+
+		assert.Equal(t, enc1, enc2)
+	})
+}
+
+func FuzzEncodeToString(f *testing.F) {
+	for _, test := range tests {
+		f.Add(test.dec)
+	}
+
+	f.Fuzz(func(t *testing.T, dec1 []byte) {
+		enc1 := EncodeToString(dec1)
+
+		dec2, err := DecodeString(enc1)
+		if err != nil {
+			t.Skip()
+		}
+
+		enc2 := EncodeToString(dec2)
+
+		assert.Equal(t, enc1, enc2)
+	})
 }


### PR DESCRIPTION
I spent some time fuzzing the nixbase32 and discovered that under some conditions (`enc = "0"`), the `DecodeString` can panic; returning an error is better-suited in this case.