### PR TITLE
fix(pkg/narinfo): Treat unknown-deriver as no deriver

### DIFF
--- a/pkg/narinfo/narinfo_test.go
+++ b/pkg/narinfo/narinfo_test.go
@@ -41,6 +41,19 @@ Deriver: 10dx1q4ivjb115y3h90mipaaz533nr0d-net-tools-1.60_p20170221182432.drv
 Sig: cache.nixos.org-1:sn5s/RrqEI+YG6/PjwdbPjcAC7rcta7sJU4mFOawGvJBLsWkyLtBrT2EuFt/LJjWkTZ+ZWOI9NTtjo/woMdvAg==
 Sig: hydra.other.net-1:JXQ3Z/PXf0EZSFkFioa4FbyYpbbTbHlFBtZf4VqU0tuMTWzhMD7p9Q7acJjLn3jofOtilAAwRILKIfVuyrbjAA==
 `
+	strNarinfoSampleWithUnknownDeriver = `
+StorePath: /nix/store/00bgd045z0d4icpbc2yyz4gx48ak44la-net-tools-1.60_p20170221182432
+URL: nar/1094wph9z4nwlgvsd53abfz8i117ykiv5dwnq9nnhz846s7xqd7d.nar.xz
+Compression: xz
+FileHash: sha256:1094wph9z4nwlgvsd53abfz8i117ykiv5dwnq9nnhz846s7xqd7d
+FileSize: 114980
+NarHash: sha256:0lxjvvpr59c2mdram7ympy5ay741f180kv3349hvfc3f8nrmbqf6
+NarSize: 464152
+References: 7gx4kiv5m0i7d7qkixq2cwzbr10lvxwc-glibc-2.27
+Deriver: unknown-deriver
+Sig: cache.nixos.org-1:sn5s/RrqEI+YG6/PjwdbPjcAC7rcta7sJU4mFOawGvJBLsWkyLtBrT2EuFt/LJjWkTZ+ZWOI9NTtjo/woMdvAg==
+Sig: hydra.other.net-1:JXQ3Z/PXf0EZSFkFioa4FbyYpbbTbHlFBtZf4VqU0tuMTWzhMD7p9Q7acJjLn3jofOtilAAwRILKIfVuyrbjAA==
+`
 	strNarinfoSampleWithoutFileFields = `
 StorePath: /nix/store/00bgd045z0d4icpbc2yyz4gx48ak44la-net-tools-1.60_p20170221182432
 URL: nar/1094wph9z4nwlgvsd53abfz8i117ykiv5dwnq9nnhz846s7xqd7d.nar.xz
@@ -139,6 +152,18 @@ Sig: hydra.other.net-1:JXQ3Z/PXf0EZSFkFioa4FbyYpbbTbHlFBtZf4VqU0tuMTWzhMD7p9Q7ac
 		Signatures:  _SignaturesNarinfoSample,
 	}
 
+	narinfoSampleWithUnknownDeriver = &narinfo.NarInfo{
+		StorePath:   "/nix/store/00bgd045z0d4icpbc2yyz4gx48ak44la-net-tools-1.60_p20170221182432",
+		URL:         "nar/1094wph9z4nwlgvsd53abfz8i117ykiv5dwnq9nnhz846s7xqd7d.nar.xz",
+		Compression: "xz",
+		FileHash:    mustParseAny("sha256:1094wph9z4nwlgvsd53abfz8i117ykiv5dwnq9nnhz846s7xqd7d"),
+		FileSize:    114980,
+		NarHash:     _NarHash,
+		NarSize:     464152,
+		References:  []string{"7gx4kiv5m0i7d7qkixq2cwzbr10lvxwc-glibc-2.27"},
+		Signatures:  _SignaturesNarinfoSample,
+	}
+
 	narinfoSampleWithoutFileFields = &narinfo.NarInfo{
 		StorePath:   "/nix/store/00bgd045z0d4icpbc2yyz4gx48ak44la-net-tools-1.60_p20170221182432",
 		URL:         "nar/1094wph9z4nwlgvsd53abfz8i117ykiv5dwnq9nnhz846s7xqd7d.nar.xz",
@@ -218,6 +243,22 @@ func TestNarInfoWithBase16Hash(t *testing.T) {
 
 	// Test to string
 	assert.Equal(t, strNarinfoSampleWithBase16Hash, "\n"+ni.String())
+}
+
+func TestNarInfoWithUnknownDeriver(t *testing.T) {
+	ni, err := narinfo.Parse(strings.NewReader(strNarinfoSampleWithUnknownDeriver))
+	assert.NoError(t, err)
+
+	// Test the parsing happy path
+	assert.Equal(t, narinfoSampleWithUnknownDeriver, ni)
+	assert.NoError(t, ni.Check())
+
+	// Test to string
+	assert.Equal(
+		t,
+		strings.Replace(strNarinfoSampleWithUnknownDeriver, "Deriver: unknown-deriver\n", "", -1),
+		"\n"+ni.String(),
+	)
 }
 
 func TestNarInfoUncompressed(t *testing.T) {

--- a/pkg/narinfo/parser.go
+++ b/pkg/narinfo/parser.go
@@ -72,7 +72,9 @@ func Parse(r io.Reader) (*NarInfo, error) {
 
 			narInfo.References = append(narInfo.References, strings.Split(v, " ")...)
 		case "Deriver":
-			narInfo.Deriver = v
+			if v != "unknown-deriver" {
+				narInfo.Deriver = v
+			}
 		case "System":
 			narInfo.System = v
 		case "Sig":


### PR DESCRIPTION
Some cache servers return `Deriver: unknown-deriver` which breaks verification of a narinfo. Treat such deriver as if no deriver was given at all.

ref https://github.com/kalbasit/ncps/issues/171